### PR TITLE
Ensure homepage animations render client-side

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { motion, useScroll, useTransform } from 'framer-motion';
 import { useState, useEffect } from 'react';
+import ClientOnly from '@/components/ClientOnly';
 /** util: run code only after React mounts (prevents hydration mismatch) */
 function useMounted() {
   const [mounted, setMounted] = useState(false);
@@ -138,7 +139,7 @@ export default function HomePage() {
         <div className="absolute inset-0 opacity-[0.85] bg-[radial-gradient(1200px_600px_at_50%_-10%,rgba(255,255,255,0.06),transparent_60%),radial-gradient(900px_500px_at_80%_10%,rgba(251,191,36,0.08),transparent_60%),radial-gradient(900px_500px_at_20%_10%,rgba(244,114,182,0.06),transparent_60%)]" />
       </div>
 
-      {mounted && <Starfield />}
+      <ClientOnly>{mounted ? <Starfield /> : null}</ClientOnly>
 
       {/* Header */}
       <header className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-16 pt-4 sm:pt-6 relative z-20">

--- a/components/ClientOnly.tsx
+++ b/components/ClientOnly.tsx
@@ -1,0 +1,7 @@
+'use client';
+import { PropsWithChildren, useEffect, useState } from 'react';
+export default function ClientOnly({ children }: PropsWithChildren) {
+  const [ready, setReady] = useState(false);
+  useEffect(() => setReady(true), []);
+  return ready ? <>{children}</> : null;
+}


### PR DESCRIPTION
## Summary
- add a reusable ClientOnly wrapper component for client-only rendering
- wrap the homepage starfield in ClientOnly to avoid server-side execution of scroll animations

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6507dfb84832c8b75888089c3d73d