### PR TITLE
refactor: centralize Supabase browser client usage

### DIFF
--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -2,7 +2,8 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { createClient, User } from '@supabase/supabase-js';
+import { User } from '@supabase/supabase-js';
+import { getSupabaseBrowser } from '@/lib/supabaseClient';
 
 type PublicCard = {
   id: string;
@@ -27,19 +28,10 @@ export default function MembersPage() {
   const [region, setRegion] = useState('');
   const [skillsCsv, setSkillsCsv] = useState(''); // "farmer, designer"
 
-  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
-  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
-
-  const supabase = useMemo(() => {
-    if (!supabaseUrl || !supabaseAnonKey) return null;
-    return createClient(supabaseUrl, supabaseAnonKey, {
-      auth: { persistSession: true, autoRefreshToken: true },
-    });
-  }, [supabaseUrl, supabaseAnonKey]);
+  const supabase = useMemo(() => getSupabaseBrowser(), []);
 
   // 1) find current signed-in user (needed for RPC)
   useEffect(() => {
-    if (!supabase) return;
     let mounted = true;
 
     const init = async () => {
@@ -76,7 +68,6 @@ export default function MembersPage() {
 
   // 2) load public list (anyone can see)
   const loadPublicList = async () => {
-    if (!supabase) return;
     setLoadingList(true);
     const { data, error } = await supabase
       .from('members_public') // ✅ read from members_public
@@ -87,7 +78,6 @@ export default function MembersPage() {
   };
 
   useEffect(() => {
-    if (!supabase) return;
     loadPublicList();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [supabase]);
@@ -95,7 +85,6 @@ export default function MembersPage() {
   // 3) submit to RPC upsert_my_profile (authenticated only)
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!supabase) return;
     setMsg('');
     if (!sessionUser) {
       setMsg('Please sign in first, then try again.');

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -2,7 +2,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/lib/supabaseClient';
 
 type Probe = {
   label: string;
@@ -18,12 +18,7 @@ export default function StatusPage() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || '';
   const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || '';
 
-  const supabase = useMemo(() => {
-    if (!supabaseUrl || !supabaseAnonKey) return null;
-    return createClient(supabaseUrl, supabaseAnonKey, {
-      auth: { persistSession: false, autoRefreshToken: false },
-    });
-  }, [supabaseUrl, supabaseAnonKey]);
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
 
   useEffect(() => {
     const run = async () => {
@@ -42,104 +37,94 @@ export default function StatusPage() {
       });
 
       // 2) Supabase Auth ping
-      if (supabase) {
-        const t0 = performance.now();
-        try {
-          const { error } = await supabase.auth.getSession();
-          const t1 = performance.now();
-          results.push({
-            label: 'Supabase Auth reachable',
-            ok: !error,
-            detail: error ? error.message : 'ok',
-            ms: Math.round(t1 - t0),
-          });
-        } catch (e: any) {
-          const t1 = performance.now();
-          results.push({
-            label: 'Supabase Auth reachable',
-            ok: false,
-            detail: e?.message || 'unknown error',
-            ms: Math.round(t1 - t0),
-          });
-        }
-      } else {
+      const t0 = performance.now();
+      try {
+        const { error } = await supabase.auth.getSession();
+        const t1 = performance.now();
+        results.push({
+          label: 'Supabase Auth reachable',
+          ok: !error,
+          detail: error ? error.message : 'ok',
+          ms: Math.round(t1 - t0),
+        });
+      } catch (e: any) {
+        const t1 = performance.now();
         results.push({
           label: 'Supabase Auth reachable',
           ok: false,
-          detail: 'client not initialized (missing env)',
+          detail: e?.message || 'unknown error',
+          ms: Math.round(t1 - t0),
         });
       }
 
       // 3) Safe DB probe (treat "no table yet" as OK during bootstrap)
-      if (supabase) {
-        const t0 = performance.now();
-        let ok = false;
-        let detail = '';
-        try {
-          // try profiles first
-          const { data, error, status } = await supabase
-            .from('profiles')
-            .select('id')
-            .limit(1);
+      const t0 = performance.now();
+      let ok = false;
+      let detail = '';
+      try {
+        // try profiles first
+        const { data, error, status } = await supabase
+          .from('profiles')
+          .select('id')
+          .limit(1);
 
-          if (error) {
-            const notFound =
-              (error as any)?.code === '42P01' || // relation does not exist
-              status === 404 ||
-              /relation .* does not exist/i.test(error.message) ||
-              /schema cache/i.test(error.message);
+        if (error) {
+          const notFound =
+            (error as any)?.code === '42P01' || // relation does not exist
+            status === 404 ||
+            /relation .* does not exist/i.test(error.message) ||
+            /schema cache/i.test(error.message);
 
-            if (notFound) {
-              // try users as an alternate common table name
-              const retry = await supabase.from('users').select('id').limit(1);
-              if (retry.error) {
-                const alsoNotFound =
-                  (retry.error as any)?.code === '42P01' ||
-                  retry.status === 404 ||
-                  /relation .* does not exist/i.test(retry.error.message) ||
-                  /schema cache/i.test(retry.error.message);
+          if (notFound) {
+            // try users as an alternate common table name
+            const retry = await supabase.from('users').select('id').limit(1);
+            if (retry.error) {
+              const alsoNotFound =
+                (retry.error as any)?.code === '42P01' ||
+                retry.status === 404 ||
+                /relation .* does not exist/i.test(retry.error.message) ||
+                /schema cache/i.test(retry.error.message);
 
-                if (alsoNotFound) {
-                  // ✅ Bootstrap mode: No tables yet is acceptable for health
-                  ok = true;
-                  detail =
-                    'No public tables yet — bootstrap mode (OK: skipped). Create tables later.';
-                } else {
-                  ok = false;
-                  detail = `users error: ${retry.error.message} (status ${retry.status})`;
-                }
-              } else {
+              if (alsoNotFound) {
+                // ✅ Bootstrap mode: No tables yet is acceptable for health
                 ok = true;
-                detail = `users ok (${retry.data?.length || 0} rows visible)`;
+                detail =
+                  'No public tables yet — bootstrap mode (OK: skipped). Create tables later.';
+              } else {
+                ok = false;
+                detail = `users error: ${retry.error.message} (status ${retry.status})`;
               }
             } else {
-              ok = false;
-              detail = `profiles error: ${error.message} (status ${status})`;
+              ok = true;
+              detail = `users ok (${retry.data?.length || 0} rows visible)`;
             }
           } else {
-            ok = true;
-            detail = `profiles ok (${data?.length || 0} rows visible)`;
-          }
-        } catch (e: any) {
-          // If server says table/view missing in any other phrasing, still skip as OK.
-          const msg = `${e?.message || ''}`;
-          if (/relation .* does not exist/i.test(msg) || /schema cache/i.test(msg)) {
-            ok = true;
-            detail =
-              'No public tables yet — bootstrap mode (OK: skipped). Create tables later.';
-          } else {
             ok = false;
-            detail = msg || 'unknown db error';
+            detail = `profiles error: ${error.message} (status ${status})`;
           }
+        } else {
+          ok = true;
+          detail = `profiles ok (${data?.length || 0} rows visible)`;
         }
-        const t1 = performance.now();
-        results.push({
-          label: 'Database probe (bootstrap-safe)',
-          ok,
-          detail,
-          ms: Math.round(t1 - t0),
-        });
+      } catch (e: any) {
+        // If server says table/view missing in any other phrasing, still skip as OK.
+        const msg = `${e?.message || ''}`;
+        if (/relation .* does not exist/i.test(msg) || /schema cache/i.test(msg)) {
+          ok = true;
+          detail =
+            'No public tables yet — bootstrap mode (OK: skipped). Create tables later.';
+        } else {
+          ok = false;
+          detail = msg || 'unknown db error';
+        }
       }
+      const t1 = performance.now();
+      results.push({
+        label: 'Database probe (bootstrap-safe)',
+        ok,
+        detail,
+        ms: Math.round(t1 - t0),
+      });
 
       setProbes(results);
     };

--- a/components/ChautariLocationPicker.jsx
+++ b/components/ChautariLocationPicker.jsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { createClient } from "@supabase/supabase-js";
+import { getSupabaseBrowser } from "@/lib/supabaseClient";
 
 /**
  * ChautariLocationPicker.jsx — Auto-Approve Edition
@@ -15,15 +15,7 @@ export default function ChautariLocationPicker({
 }) {
   const supabaseRef = useRef(null);
   if (!supabaseRef.current) {
-    if (supabaseProp) {
-      supabaseRef.current = supabaseProp;
-    } else if (typeof window !== "undefined" && process.env.NEXT_PUBLIC_SUPABASE_URL && process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
-      supabaseRef.current = createClient(
-        process.env.NEXT_PUBLIC_SUPABASE_URL,
-        process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY,
-        { auth: { persistSession: true, autoRefreshToken: true, detectSessionInUrl: true } }
-      );
-    }
+    supabaseRef.current = supabaseProp ?? getSupabaseBrowser();
   }
   const supabase = supabaseRef.current;
 

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,27 +1,2 @@
-import { createClient, type SupabaseClient } from '@supabase/supabase-js';
-
-/**
- * Server-side Supabase client without @supabase/ssr.
- * Uses SERVICE_ROLE if provided (secure server-only), otherwise falls back to anon.
- * No cookie/session persistence here; use it for backend actions/routes.
- */
-export function getServerSupabase(): SupabaseClient {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY as string | undefined;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string | undefined;
-  const key = serviceKey || anonKey;
-  if (!url || !key) {
-    throw new Error('Missing SUPABASE keys. Set NEXT_PUBLIC_SUPABASE_URL and either SUPABASE_SERVICE_ROLE_KEY or NEXT_PUBLIC_SUPABASE_ANON_KEY');
-  }
-  return createClient(url, key, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false,
-    },
-    global: {
-      headers: { 'X-Client-Info': 'gatishil/server' },
-    },
-  });
-}
-
-export { getServerSupabase as createServerClient }; // light compat if referenced by old name
+export { getServerSupabase } from '../supabaseServer';
+export { getServerSupabase as createServerClient } from '../supabaseServer';

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,16 +1,35 @@
-import { createClient } from '@supabase/supabase-js';
+"use client";
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
+import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
+const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string | undefined;
 
 if (!url || !anon) {
   // Fail fast during build if envs are missing
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
 }
 
+let browserClient: SupabaseClient | undefined;
+
+const getBrowserSingleton = (): SupabaseClient => {
+  if (!browserClient) {
+    browserClient = createBrowserClient(url, anon, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        detectSessionInUrl: true,
+        storageKey: 'gatishil.auth.token',
+      },
+    });
+  }
+  return browserClient;
+};
+
 // Browser-safe singleton client
-export const supabase = createClient(url, anon);
+export const supabase = getBrowserSingleton();
 
 // Alias names to satisfy various imports across the app
-export const getSupabaseBrowser = () => supabase;
-export const getSupabaseBrowserClient = () => supabase;
+export const getSupabaseBrowser = () => getBrowserSingleton();
+export const getSupabaseBrowserClient = () => getBrowserSingleton();


### PR DESCRIPTION
## Summary
- switch the browser Supabase singleton to use @supabase/ssr for session-aware reuse
- update members directory, status checks, and location picker to consume the shared client and rely on the server helper export

## Testing
- not run (dependencies not installed in container)

------
https://chatgpt.com/codex/tasks/task_e_68e653834624832c87bea8442c49554b