### PR TITLE
Fix duplicate timer variables in status page health checks

### DIFF
--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -43,23 +43,23 @@ export default function StatusPage() {
 
       // 2) Supabase Auth ping
       if (supabase) {
-        const t0 = performance.now();
+        const authStart = performance.now();
         try {
           const { error } = await supabase.auth.getSession();
-          const t1 = performance.now();
+          const authEnd = performance.now();
           results.push({
             label: 'Supabase Auth reachable',
             ok: !error,
             detail: error ? error.message : 'ok',
-            ms: Math.round(t1 - t0),
+            ms: Math.round(authEnd - authStart),
           });
         } catch (e: any) {
-          const t1 = performance.now();
+          const authEnd = performance.now();
           results.push({
             label: 'Supabase Auth reachable',
             ok: false,
             detail: e?.message || 'unknown error',
-            ms: Math.round(t1 - t0),
+            ms: Math.round(authEnd - authStart),
           });
         }
       } else {
@@ -72,7 +72,7 @@ export default function StatusPage() {
 
       // 3) Safe DB probe (treat "no table yet" as OK during bootstrap)
       if (supabase) {
-        const t0 = performance.now();
+        const dbStart = performance.now();
         let ok = false;
         let detail = '';
         try {
@@ -132,12 +132,12 @@ export default function StatusPage() {
             detail = msg || 'unknown db error';
           }
         }
-        const t1 = performance.now();
+        const dbEnd = performance.now();
         results.push({
           label: 'Database probe (bootstrap-safe)',
           ok,
           detail,
-          ms: Math.round(t1 - t0),
+          ms: Math.round(dbEnd - dbStart),
         });
       }
 


### PR DESCRIPTION
## Summary
- rename the Supabase auth probe timer variables to avoid redeclaration conflicts
- rename the database probe timer variables to keep the page build-safe

## Testing
- npm run lint *(fails: local Next.js binary unavailable because npm install is blocked by 403 fetching @simplewebauthn/browser)*

------
https://chatgpt.com/codex/tasks/task_e_68e655f5acf4832c84033290d7bb10f7