### PR TITLE
Remove client-side noStore call from join page

### DIFF
--- a/app/join/page.tsx
+++ b/app/join/page.tsx
@@ -3,7 +3,6 @@
 
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { unstable_noStore as noStore } from 'next/cache';
 import { supabase } from '@/lib/supabaseClient';
 import { COUNTRIES } from '@/app/data/countries';
 
@@ -61,7 +60,6 @@ async function safeFetch(url: string, init: RequestInit, timeoutMs = 10000) {
 
 // ---------- Client component ----------
 function JoinClient() {
-  noStore(); // be explicit: never cache this render
 
   const router = useRouter();
   const _params = useSearchParams(); // kept for potential future use


### PR DESCRIPTION
## Summary
- remove the client-side call to `unstable_noStore` from the join page so the component no longer invokes a server-only API at runtime

## Testing
- not run (npm install blocked by registry restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68e65b4fd184832cbcad18948e68d550