### PR TITLE
Handle missing Supabase env gracefully on status page

### DIFF
--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -136,6 +136,12 @@ export default function StatusPage() {
           detail,
           ms: dbTimer(),
         });
+      } else {
+        results.push({
+          label: 'Database probe (bootstrap-safe)',
+          ok: false,
+          detail: 'client not initialized (missing env)',
+        });
       }
 
       setProbes(results);
@@ -241,7 +247,9 @@ export default function StatusPage() {
   );
 }
 
-function startTimer() {
+type Timer = () => number;
+
+function startTimer(): Timer {
   const now = () =>
     typeof performance !== 'undefined' ? performance.now() : Date.now();
   const started = now();


### PR DESCRIPTION
## Summary
- ensure the database probe reports missing Supabase credentials instead of silently skipping
- add a typed timer helper for consistent probe timing code

## Testing
- npm run lint *(fails: next command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65d01811c832ca6a10b100257be21