### PR TITLE
Refactor timer helper in status page

### DIFF
--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -249,9 +249,10 @@ export default function StatusPage() {
 
 type Timer = () => number;
 
+const now = () =>
+  typeof performance !== 'undefined' ? performance.now() : Date.now();
+
 function startTimer(): Timer {
-  const now = () =>
-    typeof performance !== 'undefined' ? performance.now() : Date.now();
   const started = now();
   return () => Math.round(now() - started);
 }


### PR DESCRIPTION
## Summary
- reuse a shared high-resolution `now` helper for the status page timer utility to prevent duplicate inline definitions

## Testing
- npm run lint *(fails: Next.js CLI unavailable before installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68e65e82045c832c96124e0b3f99b98d