### PR TITLE
Use shared timers for status probes

### DIFF
--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -46,18 +46,20 @@ export default function StatusPage() {
         const authTimer = startTimer();
         try {
           const { error } = await supabase.auth.getSession();
+          const ms = authTimer();
           results.push({
             label: 'Supabase Auth reachable',
             ok: !error,
             detail: error ? error.message : 'ok',
-            ms: authTimer(),
+            ms,
           });
         } catch (e: any) {
+          const ms = authTimer();
           results.push({
             label: 'Supabase Auth reachable',
             ok: false,
             detail: e?.message || 'unknown error',
-            ms: authTimer(),
+            ms,
           });
         }
       } else {
@@ -130,11 +132,12 @@ export default function StatusPage() {
             detail = msg || 'unknown db error';
           }
         }
+        const ms = dbTimer();
         results.push({
           label: 'Database probe (bootstrap-safe)',
           ok,
           detail,
-          ms: dbTimer(),
+          ms,
         });
       } else {
         results.push({


### PR DESCRIPTION
## Summary
- capture Supabase auth and database probe durations once before recording results
- reuse the measured milliseconds when building probe output objects

## Testing
- npm run lint *(fails: next not found in PATH prior to installing dependencies)*
- npm install *(fails: 403 fetching @simplewebauthn/browser from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68e660014a48832ca5b43dc4fd1c3fa9