### PR TITLE
Fix WebAuthn routes to self-authenticate via Supabase cookies

### DIFF
--- a/app/api/webauthn/options/route.ts
+++ b/app/api/webauthn/options/route.ts
@@ -1,75 +1,208 @@
-// Next.js 14 App Router – WebAuthn Registration Options
 export const runtime = "nodejs";
 
 import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
-import type { Database } from "@/types/supabase"; // adjust if needed
-
-import { setChallengeCookie, deriveRpID, expectedOrigins, rpName } from "@/lib/webauthn";
+import { createClient } from "@supabase/supabase-js";
 import { generateRegistrationOptions } from "@simplewebauthn/server";
 
-function supabaseServer() {
-  const cookieStore = cookies();
-  return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) { return cookieStore.get(name)?.value; },
-        set(name: string, value: string, options: any) { cookieStore.set({ name, value, ...options }); },
-        remove(name: string, options: any) { cookieStore.set({ name, value: "", ...options }); },
-      },
+import { deriveRpID, expectedOrigins, rpName, setChallengeCookie } from "@/lib/webauthn";
+
+class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+  }
+}
+
+type JwtPayload = {
+  sub?: unknown;
+  email?: unknown;
+  exp?: unknown;
+  user_metadata?: { email?: unknown } | null;
+};
+
+type SupabaseIdentity = {
+  userId: string;
+  email: string | null;
+};
+
+function normalizeBase64Url(segment: string): string {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+  return normalized + "=".repeat(padding);
+}
+
+function decodeJwtPayload(token: string): JwtPayload {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new UnauthorizedError();
+  }
+
+  const payloadSegment = normalizeBase64Url(parts[1]);
+
+  try {
+    let json: string;
+    if (typeof Buffer !== "undefined") {
+      json = Buffer.from(payloadSegment, "base64").toString("utf-8");
+    } else if (typeof atob === "function") {
+      const binary = atob(payloadSegment);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      json = new TextDecoder().decode(bytes);
+    } else {
+      throw new Error("No base64 decoder available");
     }
-  );
+
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? (parsed as JwtPayload) : {};
+  } catch (error) {
+    throw new UnauthorizedError();
+  }
+}
+
+function assertTokenNotExpired(payload: JwtPayload) {
+  const { exp } = payload;
+  if (typeof exp === "number") {
+    if (exp * 1000 <= Date.now()) {
+      throw new UnauthorizedError();
+    }
+  } else if (typeof exp === "string") {
+    const asNumber = Number(exp);
+    if (!Number.isNaN(asNumber) && asNumber * 1000 <= Date.now()) {
+      throw new UnauthorizedError();
+    }
+  }
+}
+
+function extractIdentity(payload: JwtPayload): SupabaseIdentity {
+  const rawSub = payload.sub;
+  if (typeof rawSub !== "string" || rawSub.length === 0) {
+    throw new UnauthorizedError();
+  }
+
+  const primaryEmail = typeof payload.email === "string" ? payload.email : null;
+  const metadataEmail =
+    payload.user_metadata && typeof payload.user_metadata.email === "string"
+      ? payload.user_metadata.email
+      : null;
+
+  return {
+    userId: rawSub,
+    email: primaryEmail || metadataEmail || null,
+  };
+}
+
+function resolveSupabaseIdentity(token: string): SupabaseIdentity {
+  const payload = decodeJwtPayload(token);
+  assertTokenNotExpired(payload);
+  return extractIdentity(payload);
+}
+
+function resolveAccessToken(
+  hdrs: Headers,
+  cookieStore: ReturnType<typeof cookies>,
+): string {
+  const authHeader = hdrs.get("authorization");
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+
+  const cookieToken = cookieStore.get("sb-access-token")?.value;
+  if (cookieToken && cookieToken.length > 0) {
+    return cookieToken;
+  }
+
+  throw new UnauthorizedError();
+}
+
+function createSupabaseClient(accessToken: string) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    throw new Error("Missing Supabase environment variables");
+  }
+
+  return createClient(url, anon, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
 }
 
 export async function POST() {
+  const hdrs = headers();
+  const cookieStore = cookies();
+
   try {
-    const hdrs = headers();
+    const accessToken = resolveAccessToken(hdrs, cookieStore);
+    const { userId, email } = resolveSupabaseIdentity(accessToken);
+
     const host = hdrs.get("host");
     const rpID = deriveRpID(host);
 
-    const supabase = supabaseServer();
-    const { data: { user }, error: userErr } = await supabase.auth.getUser();
-    if (userErr || !user) {
-      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-    }
-
-    // Avoid duplicate registration on the same account
-    const { data: existing, error: credErr } = await supabase
+    const supabase = createSupabaseClient(accessToken);
+    const { data: existing, error: existingError } = await supabase
       .from("webauthn_credentials")
       .select("credential_id")
-      .eq("user_id", user.id);
-    if (credErr) {
-      console.error("[webauthn/options] credential preload error", credErr);
+      .eq("user_id", userId);
+
+    if (existingError) {
+      console.error("[webauthn/options] failed to load credentials", existingError);
+      return NextResponse.json(
+        { ok: false, error: "Failed to preload credentials" },
+        { status: 500 },
+      );
     }
 
-    const excludeCredentials = (existing ?? []).map((c: any) => ({
-      id: c.credential_id,
+    const excludeCredentials = (existing ?? []).map((row) => ({
+      id: row.credential_id,
       type: "public-key" as const,
     }));
 
     const options = await generateRegistrationOptions({
       rpName: rpName ?? "Gatishil Nepal",
       rpID,
-      userID: user.id,
-      userName: user.email ?? user.id,
+      userID: userId,
+      userName: email ?? userId,
       attestationType: "none",
       authenticatorSelection: {
         authenticatorAttachment: "platform",
         residentKey: "required",
         userVerification: "preferred",
       },
-      timeout: 60000,
+      timeout: 60_000,
       excludeCredentials,
     });
 
-    const res = NextResponse.json({ ok: true, options, expectedOrigins: Array.from(expectedOrigins) });
-    setChallengeCookie(res, options.challenge);
-    return res;
-  } catch (err: any) {
-    console.error("[webauthn/options] error", err);
-    return NextResponse.json({ ok: false, error: "Failed to create options", detail: String(err?.message || err) }, { status: 500 });
+    const response = NextResponse.json({
+      ok: true,
+      options,
+      expectedOrigins: Array.from(expectedOrigins),
+    });
+
+    setChallengeCookie(response, options.challenge);
+    return response;
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    console.error("[webauthn/options] error", error);
+    return NextResponse.json(
+      { ok: false, error: "Failed to create options" },
+      { status: 500 },
+    );
   }
 }

--- a/app/api/webauthn/verify/route.ts
+++ b/app/api/webauthn/verify/route.ts
@@ -1,41 +1,162 @@
-// Next.js 14 App Router – WebAuthn Registration Verify
 export const runtime = "nodejs";
 
-import { headers, cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 import { NextResponse } from "next/server";
-import { createServerClient } from "@supabase/ssr";
-import type { Database } from "@/types/supabase";
-
-import {
-  deriveRpID,
-  expectedOrigins,
-  readChallengeCookie,
-  clearChallengeCookie,
-  extractRegistrationCredential,
-  toBase64Url,
-} from "@/lib/webauthn";
-
+import { createClient } from "@supabase/supabase-js";
 import { verifyRegistrationResponse } from "@simplewebauthn/server";
 import type { RegistrationResponseJSON } from "@simplewebauthn/types";
 
-function supabaseServer() {
-  const cookieStore = cookies();
-  return createServerClient<Database>(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) { return cookieStore.get(name)?.value; },
-        set(name: string, value: string, options: any) { cookieStore.set({ name, value, ...options }); },
-        remove(name: string, options: any) { cookieStore.set({ name, value: "", ...options }); },
-      },
+import {
+  clearChallengeCookie,
+  deriveRpID,
+  expectedOrigins,
+  extractRegistrationCredential,
+  readChallengeCookie,
+  toBase64Url,
+} from "@/lib/webauthn";
+
+class UnauthorizedError extends Error {
+  constructor(message = "Unauthorized") {
+    super(message);
+  }
+}
+
+type JwtPayload = {
+  sub?: unknown;
+  email?: unknown;
+  exp?: unknown;
+  user_metadata?: { email?: unknown } | null;
+};
+
+type SupabaseIdentity = {
+  userId: string;
+  email: string | null;
+};
+
+function normalizeBase64Url(segment: string): string {
+  const normalized = segment.replace(/-/g, "+").replace(/_/g, "/");
+  const padding = normalized.length % 4 === 0 ? 0 : 4 - (normalized.length % 4);
+  return normalized + "=".repeat(padding);
+}
+
+function decodeJwtPayload(token: string): JwtPayload {
+  const parts = token.split(".");
+  if (parts.length !== 3) {
+    throw new UnauthorizedError();
+  }
+
+  const payloadSegment = normalizeBase64Url(parts[1]);
+
+  try {
+    let json: string;
+    if (typeof Buffer !== "undefined") {
+      json = Buffer.from(payloadSegment, "base64").toString("utf-8");
+    } else if (typeof atob === "function") {
+      const binary = atob(payloadSegment);
+      const bytes = new Uint8Array(binary.length);
+      for (let i = 0; i < binary.length; i += 1) {
+        bytes[i] = binary.charCodeAt(i);
+      }
+      json = new TextDecoder().decode(bytes);
+    } else {
+      throw new Error("No base64 decoder available");
     }
-  );
+
+    const parsed = JSON.parse(json);
+    return parsed && typeof parsed === "object" ? (parsed as JwtPayload) : {};
+  } catch (error) {
+    throw new UnauthorizedError();
+  }
+}
+
+function assertTokenNotExpired(payload: JwtPayload) {
+  const { exp } = payload;
+  if (typeof exp === "number") {
+    if (exp * 1000 <= Date.now()) {
+      throw new UnauthorizedError();
+    }
+  } else if (typeof exp === "string") {
+    const asNumber = Number(exp);
+    if (!Number.isNaN(asNumber) && asNumber * 1000 <= Date.now()) {
+      throw new UnauthorizedError();
+    }
+  }
+}
+
+function extractIdentity(payload: JwtPayload): SupabaseIdentity {
+  const rawSub = payload.sub;
+  if (typeof rawSub !== "string" || rawSub.length === 0) {
+    throw new UnauthorizedError();
+  }
+
+  const primaryEmail = typeof payload.email === "string" ? payload.email : null;
+  const metadataEmail =
+    payload.user_metadata && typeof payload.user_metadata.email === "string"
+      ? payload.user_metadata.email
+      : null;
+
+  return {
+    userId: rawSub,
+    email: primaryEmail || metadataEmail || null,
+  };
+}
+
+function resolveSupabaseIdentity(token: string): SupabaseIdentity {
+  const payload = decodeJwtPayload(token);
+  assertTokenNotExpired(payload);
+  return extractIdentity(payload);
+}
+
+function resolveAccessToken(
+  hdrs: Headers,
+  cookieStore: ReturnType<typeof cookies>,
+): string {
+  const authHeader = hdrs.get("authorization");
+  if (authHeader) {
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (match && match[1]) {
+      return match[1].trim();
+    }
+  }
+
+  const cookieToken = cookieStore.get("sb-access-token")?.value;
+  if (cookieToken && cookieToken.length > 0) {
+    return cookieToken;
+  }
+
+  throw new UnauthorizedError();
+}
+
+function createSupabaseClient(accessToken: string) {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    throw new Error("Missing Supabase environment variables");
+  }
+
+  return createClient(url, anon, {
+    global: {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    },
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
 }
 
 export async function POST(req: Request) {
+  const hdrs = headers();
+  const cookieStore = cookies();
+
   try {
-    const hdrs = headers();
+    const accessToken = resolveAccessToken(hdrs, cookieStore);
+    const { userId } = resolveSupabaseIdentity(accessToken);
+
     const host = hdrs.get("host");
     const cookieHeader = hdrs.get("cookie");
     const rpID = deriveRpID(host);
@@ -52,11 +173,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: "Missing challenge" }, { status: 400 });
     }
 
-    const supabase = supabaseServer();
-    const { data: { user }, error: userErr } = await supabase.auth.getUser();
-    if (userErr || !user) {
-      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
-    }
+    const supabase = createSupabaseClient(accessToken);
 
     const verification = await verifyRegistrationResponse({
       expectedChallenge: challenge,
@@ -82,12 +199,11 @@ export async function POST(req: Request) {
     const credIdStr = toBase64Url(credentialID);
     const pubKeyStr = toBase64Url(credentialPublicKey);
 
-    // 1) Upsert the new credential
-    const { error: upsertErr } = await supabase
+    const { error: upsertError } = await supabase
       .from("webauthn_credentials")
       .upsert(
         {
-          user_id: user.id,
+          user_id: userId,
           credential_id: credIdStr,
           public_key: pubKeyStr,
           counter: counter ?? 0,
@@ -95,44 +211,50 @@ export async function POST(req: Request) {
           backed_up: credentialBackedUp ?? null,
           transports: credentialTransports ?? null,
         },
-        { onConflict: "credential_id" }
+        { onConflict: "credential_id" },
       );
 
-    if (upsertErr) {
-      console.error("[webauthn/verify] credential upsert failed", upsertErr);
+    if (upsertError) {
+      console.error("[webauthn/verify] credential upsert failed", upsertError);
       return NextResponse.json({ ok: false, error: "DB upsert failed" }, { status: 500 });
     }
 
-    // 2) Update user flags & list
-    const { data: urow, error: urowErr } = await supabase
+    const { data: userRow, error: userRowError } = await supabase
       .from("users")
       .select("passkey_cred_ids")
-      .eq("id", user.id)
+      .eq("id", userId)
       .single();
 
-    if (urowErr) {
-      console.error("[webauthn/verify] user row load failed", urowErr);
+    if (userRowError) {
+      console.error("[webauthn/verify] user row load failed", userRowError);
       return NextResponse.json({ ok: false, error: "User row missing" }, { status: 500 });
     }
 
-    const ids: string[] = Array.isArray(urow?.passkey_cred_ids) ? urow.passkey_cred_ids : [];
+    const ids: string[] = Array.isArray(userRow?.passkey_cred_ids) ? userRow.passkey_cred_ids : [];
     if (!ids.includes(credIdStr)) ids.push(credIdStr);
 
-    const { error: userUpdateErr } = await supabase
+    const { error: userUpdateError } = await supabase
       .from("users")
       .update({ passkey_enabled: true, passkey_cred_ids: ids })
-      .eq("id", user.id);
+      .eq("id", userId);
 
-    if (userUpdateErr) {
-      console.error("[webauthn/verify] users update failed", userUpdateErr);
+    if (userUpdateError) {
+      console.error("[webauthn/verify] users update failed", userUpdateError);
       return NextResponse.json({ ok: false, error: "User update failed" }, { status: 500 });
     }
 
-    const res = NextResponse.json({ ok: true, credential_id: credIdStr });
-    clearChallengeCookie(res);
-    return res;
-  } catch (err: any) {
-    console.error("[webauthn/verify] error", err);
-    return NextResponse.json({ ok: false, error: "Verification exception", detail: String(err?.message || err) }, { status: 500 });
+    const response = NextResponse.json({ ok: true, credential_id: credIdStr });
+    clearChallengeCookie(response);
+    return response;
+  } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+    }
+
+    console.error("[webauthn/verify] error", error);
+    return NextResponse.json(
+      { ok: false, error: "Verification exception" },
+      { status: 500 },
+    );
   }
 }

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,53 +1,15 @@
-// middleware.ts
-import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
-
-/**
- * Middleware responsibilities:
- * 1) (Optional) Canonicalize page requests to a chosen host (kept disabled).
- * 2) For /api/webauthn/*, forward Supabase sb-access-token cookie as Authorization header,
- *    so Edge Route Handlers can always identify the user.
- */
-const ENABLE_HOST_CANON = false;
-const CANON_HOST = 'gatishilnepal.org'; // unused while canon is disabled
-
-function maybeCanonicalRedirect(req: NextRequest): NextResponse | null {
-  if (!ENABLE_HOST_CANON) return null;
-  const url = req.nextUrl.clone();
-  const host = url.hostname.toLowerCase();
-  if (host !== CANON_HOST && req.method === 'GET' && !url.pathname.startsWith('/api/')) {
-    url.hostname = CANON_HOST;
-    return NextResponse.redirect(url, 307);
-  }
-  return null;
-}
+import type { NextRequest } from 'next/server';
 
 export function middleware(req: NextRequest) {
-  // If you later enable canonicalization, keep API untouched.
-  if (!req.nextUrl.pathname.startsWith('/api/webauthn/')) {
-    const canon = maybeCanonicalRedirect(req);
-    if (canon) return canon;
-    return NextResponse.next();
+  const res = NextResponse.next();
+  const token = req.cookies.get('sb-access-token')?.value;
+  if (token && req.nextUrl.pathname.startsWith('/api/webauthn/')) {
+    res.headers.set('Authorization', `Bearer ${token}`);
   }
-
-  // 🔐 For /api/webauthn/*: forward Supabase access token to Authorization header
-  const access = req.cookies.get('sb-access-token')?.value;
-  const requestHeaders = new Headers(req.headers);
-
-  if (access) {
-    requestHeaders.set('Authorization', `Bearer ${access}`);
-  }
-
-  // Pass modified headers to the downstream Edge/Node handler
-  return NextResponse.next({
-    request: { headers: requestHeaders },
-  });
+  return res;
 }
 
-// Run on WebAuthn API + normal pages (exclude static assets/_next by pattern)
 export const config = {
-  matcher: [
-    '/api/webauthn/:path*',
-    '/((?!_next/|favicon\\.ico$|robots\\.txt$|sitemap\\.xml$|manifest\\.webmanifest$|images/|fonts/|assets/).*)',
-  ],
+  matcher: ['/api/webauthn/:path*'],
 };


### PR DESCRIPTION
## Summary
- decode Supabase JWTs locally to resolve the authenticated user for WebAuthn API routes
- initialize Supabase clients with bearer headers so database calls honor the session without remote auth lookups
- streamline middleware to always forward sb-access-token as an Authorization header for WebAuthn endpoints

## Testing
- npm run lint *(fails: next binary not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed2b2f2494832cbb701278a47f1e67