### PR TITLE
Normalize apex routing and gate TrustStep PIN

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { createServerClient } from '@supabase/ssr';
 
 function resolveAccessToken(req: NextRequest): string | null {
   const sb = req.cookies.get('sb-access-token')?.value;
@@ -21,17 +22,66 @@ function resolveAccessToken(req: NextRequest): string | null {
   return null;
 }
 
-export function middleware(req: NextRequest) {
-  const res = NextResponse.next();
+const PROTECTED_PATHS = ['/dashboard'];
+
+function isProtectedPath(pathname: string) {
+  return PROTECTED_PATHS.some((path) => pathname === path || pathname.startsWith(`${path}/`));
+}
+
+export async function middleware(req: NextRequest) {
+  const hostname = req.nextUrl.hostname.toLowerCase();
+  if (hostname === 'www.gatishilnepal.org') {
+    const url = req.nextUrl.clone();
+    url.hostname = 'gatishilnepal.org';
+    return NextResponse.redirect(url, 301);
+  }
+
   if (req.nextUrl.pathname.startsWith('/api/webauthn/')) {
+    const res = NextResponse.next();
     const token = resolveAccessToken(req);
     if (token) {
       res.headers.set('Authorization', `Bearer ${token}`);
     }
+    return res;
   }
+
+  const res = NextResponse.next();
+
+  if (isProtectedPath(req.nextUrl.pathname)) {
+    const supabase = createServerClient<any>(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+      {
+        cookies: {
+          get(name: string) {
+            return req.cookies.get(name)?.value;
+          },
+          set(name: string, value: string, options: any) {
+            res.cookies.set({ name, value, ...options });
+          },
+          remove(name: string, options: any) {
+            res.cookies.set({ name, value: '', ...options, maxAge: 0 });
+          },
+        },
+      }
+    );
+
+    const { data: { user }, error } = await supabase.auth.getUser();
+
+    if (error || !user) {
+      const loginUrl = new URL('/login', req.nextUrl);
+      const nextPath = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+      loginUrl.searchParams.set('next', nextPath);
+      return NextResponse.redirect(loginUrl);
+    }
+  }
+
   return res;
 }
 
 export const config = {
-  matcher: ['/api/webauthn/:path*'],
+  matcher: [
+    '/((?!_next/|.*\\.(?:png|jpg|jpeg|gif|svg|ico|webp|avif)|favicon\\.ico).*)',
+    '/api/webauthn/:path*',
+  ],
 };


### PR DESCRIPTION
## Summary
- normalize www.gatishilnepal.org requests to the apex domain and enforce Supabase-authenticated access to protected pages without introducing absolute login hosts
- keep the WebAuthn API flow reachable while preserving the Authorization header injection in middleware
- gate the TrustStep PIN form behind passkey availability checks (with desktop fallback), show the new success copy, and navigate to the dashboard with router.push after saving the PIN

## Testing
- npm run lint *(fails: `next` binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ee46334b40832cafbd5ff6f33e46a0