### PR TITLE
Implement Nepal OTP join and verification flow

### DIFF
--- a/app/api/otp/send/route.ts
+++ b/app/api/otp/send/route.ts
@@ -1,34 +1,127 @@
-// Facade kept for future throttling or SMS channel customization.
-// For now, the pages call supabase.auth directly. We expose this route so we can
-// pivot later without UI changes. Do not remove Aakash settings.
+import { createHash, randomInt } from 'crypto';
 import { NextResponse } from 'next/server';
-import { isEmail, isPhone } from '@/lib/auth/validate';
+import { isEmail } from '@/lib/auth/validate';
 import { canSendOtp } from '@/lib/auth/rateLimit';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { OTP_TTL_SECONDS } from '@/lib/constants/auth';
+
+const NEPAL_PHONE_REGEX = /^\+977\d{8,11}$/;
+
+function success() {
+  return NextResponse.json({ ok: true });
+}
+
+function genericFailure(status = 400) {
+  return NextResponse.json({ ok: false }, { status });
+}
+
+async function sendSmsViaAakash(phone: string, code: string) {
+  const apiKey = process.env.AAKASH_SMS_API_KEY;
+  const sender = process.env.AAKASH_SMS_SENDER;
+  if (!apiKey || !sender) {
+    throw Object.assign(new Error('SMS unavailable'), { statusCode: 503 });
+  }
+
+  const payload = {
+    sender,
+    to: phone,
+    text: `Your Gatishil Nepal code is ${code}. It expires in 5 minutes.`,
+  };
+
+  const response = await fetch('https://sms.aakashsms.com/sms/v3/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = new Error('SMS send failed');
+    (error as any).statusCode = 503;
+    throw error;
+  }
+}
 
 export async function POST(req: Request) {
   try {
-    const { identifier } = await req.json();
-    if (typeof identifier !== 'string') {
-      return NextResponse.json({ ok: true }, { status: 200 }); // generic
+    const body = await req.json().catch(() => ({}));
+    const phone = typeof body?.phone === 'string' ? body.phone.trim() : undefined;
+    const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : undefined;
+
+    if (email && isEmail(email)) {
+      const supabase = createAdminClient();
+      const { error } = await supabase.auth.signInWithOtp({
+        email,
+        options: { shouldCreateUser: true },
+      });
+      if (error) {
+        return NextResponse.json({ ok: false, error: error.message }, { status: 400 });
+      }
+      return success();
     }
 
-    const id = identifier.trim();
+    if (!phone) {
+      return success();
+    }
+
+    if (!NEPAL_PHONE_REGEX.test(phone)) {
+      return genericFailure(400);
+    }
+
     const ip = (req.headers.get('x-forwarded-for') ?? 'unknown').split(',')[0].trim();
-    const key = `otp:${id}:${ip}`;
-
-    if (!isEmail(id) && !isPhone(id)) {
-      return NextResponse.json({ ok: true }, { status: 200 });
-    }
-
+    const key = `otp:${phone}:${ip}`;
     if (!canSendOtp(key)) {
-      return NextResponse.json({ ok: true }, { status: 200 }); // generic throttle response
+      return success();
     }
 
-    // No-op for now; UI calls Supabase directly. We keep this endpoint for upgrades.
-    // Preserve Aakash envs; do not delete or modify them.
+    const admin = createAdminClient();
 
-    return NextResponse.json({ ok: true });
-  } catch {
-    return NextResponse.json({ ok: true }, { status: 200 });
+    async function generateOtp() {
+      return admin.auth.admin.generateLink({
+        type: 'otp',
+        phone,
+      } as any);
+    }
+
+    let { data, error: linkError } = await generateOtp();
+
+    if (linkError && /not found/i.test(linkError.message || '')) {
+      const { error: createError } = await admin.auth.admin.createUser({
+        phone,
+        phone_confirm: false,
+      } as any);
+      if (createError && !/already/i.test(createError.message || '')) {
+        return NextResponse.json({ ok: false, error: createError.message }, { status: 500 });
+      }
+      ({ data, error: linkError } = await generateOtp());
+    }
+
+    if (linkError) {
+      return NextResponse.json({ ok: false, error: linkError.message }, { status: 500 });
+    }
+
+    const code = (data as any)?.properties?.phone_otp ?? String(randomInt(0, 1_000_000)).padStart(6, '0');
+    const hashed =
+      (data as any)?.properties?.hashed_token ?? createHash('sha256').update(code).digest('hex');
+
+    const { error: insertError } = await admin
+      .from('otps')
+      .insert({ phone, code: hashed, meta: { ttl: OTP_TTL_SECONDS } });
+
+    if (insertError) {
+      return NextResponse.json({ ok: false, error: insertError.message }, { status: 500 });
+    }
+
+    await sendSmsViaAakash(phone, code);
+
+    return success();
+  } catch (error: any) {
+    const status = error?.statusCode === 503 ? 503 : 500;
+    if (status === 503) {
+      return NextResponse.json({ ok: false }, { status });
+    }
+    return NextResponse.json({ ok: false }, { status });
   }
 }

--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -1,38 +1,16 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
-import { COUNTRIES } from '@/app/data/countries';
+import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { supabase, resetLocalSessionIfInvalid } from '@/lib/supabase/client';
+import { isEmail } from '@/lib/auth/validate';
 
-const SMS_ENABLED = process.env.NEXT_PUBLIC_AUTH_SMS_ENABLED === 'true';
-
-function toE164(countryDial: string, raw: string) {
-  const digits = raw.replace(/\D/g, '');
-  const dialDigits = countryDial.replace(/\D/g, '');
-  if (!digits) return '';
-  const normalized = digits.startsWith(dialDigits) ? digits : `${dialDigits}${digits}`;
-  return `+${normalized}`;
-}
-
-function isEmail(value: string) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
-}
+const NEPAL_PHONE_REGEX = /^\+977\d{8,11}$/;
 
 export default function JoinClient() {
-  const router = useRouter();
-
-  const [tab, setTab] = useState<'phone' | 'email'>(SMS_ENABLED ? 'phone' : 'email');
-  const [countryDial, setCountryDial] = useState(() => (COUNTRIES[0] as { dial: string }).dial);
-  const [phone, setPhone] = useState('');
   const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [loadingKey, setLoadingKey] = useState<'phone' | 'email' | null>(null);
-
-  const siteUrl = useMemo(
-    () => (process.env.NEXT_PUBLIC_SITE_URL || '').replace(/\/$/, ''),
-    []
-  );
+  const [loading, setLoading] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -41,14 +19,13 @@ export default function JoinClient() {
       await resetLocalSessionIfInvalid();
       try {
         const { data } = await supabase.auth.getSession();
-        if (!cancelled && data.session) {
-          router.replace('/onboard?src=join');
+        if (!cancelled && data.session && typeof window !== 'undefined') {
+          window.location.replace('/onboard?src=join');
           return;
         }
       } catch {}
-      if (typeof window !== 'undefined') {
+      if (!cancelled && typeof window !== 'undefined') {
         sessionStorage.removeItem('pending_id');
-        sessionStorage.removeItem('pending_channel');
       }
     }
 
@@ -56,181 +33,133 @@ export default function JoinClient() {
     return () => {
       cancelled = true;
     };
-  }, [router]);
+  }, []);
+
+  const normalizedEmail = useMemo(() => email.trim().toLowerCase(), [email]);
+  const normalizedPhone = useMemo(() => phone.trim(), [phone]);
+  const emailValid = isEmail(normalizedEmail);
+  const phoneValid = NEPAL_PHONE_REGEX.test(normalizedPhone);
+  const bothFilled = normalizedEmail.length > 0 && normalizedPhone.length > 0;
 
   useEffect(() => {
-    setError(null);
-  }, [tab]);
-
-  async function handlePhoneSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (loadingKey || !SMS_ENABLED) return;
-    setLoadingKey('phone');
-    setError(null);
-
-    try {
-      const formatted = toE164(countryDial, phone);
-      if (!/^\+\d{10,15}$/.test(formatted)) {
-        throw new Error('Enter a valid phone number.');
-      }
-
-      const { error: sendError } = await supabase.auth.signInWithOtp({ phone: formatted });
-      if (sendError) throw sendError;
-
-      if (typeof window !== 'undefined') {
-        sessionStorage.setItem('pending_id', formatted);
-        sessionStorage.setItem('pending_channel', 'phone');
-      }
-
-      router.push('/verify');
-    } catch (err: any) {
-      setError(err?.message || 'Could not send SMS code. Please try again.');
-    } finally {
-      setLoadingKey(null);
+    if (!loading) {
+      setError(null);
     }
-  }
+  }, [normalizedEmail, normalizedPhone, loading]);
 
-  async function handleEmailSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    if (loadingKey) return;
-    setLoadingKey('email');
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (loading) return;
+
     setError(null);
+    setLoading(true);
 
     try {
-      if (!isEmail(email)) {
-        throw new Error('Enter a valid email.');
+      if (emailValid) {
+        const { error: sendError } = await supabase.auth.signInWithOtp({
+          email: normalizedEmail,
+          options: { shouldCreateUser: true },
+        });
+        if (sendError) throw sendError;
+
+        if (typeof window !== 'undefined') {
+          sessionStorage.setItem('pending_id', normalizedEmail);
+          window.location.href = '/verify';
+        }
+        return;
       }
 
-      const normalized = email.trim().toLowerCase();
-      const { error: sendError } = await supabase.auth.signInWithOtp({
-        email: normalized,
-        options: { shouldCreateUser: true },
+      if (!phoneValid) {
+        if (normalizedPhone && !normalizedPhone.startsWith('+977')) {
+          setError('Phone OTP is Nepal-only. Enter +977… or use email.');
+        } else {
+          setError('Phone OTP is Nepal-only. Enter +977… or use email.');
+        }
+        return;
+      }
+
+      const response = await fetch('/api/otp/send', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ phone: normalizedPhone }),
       });
-      if (sendError) throw sendError;
+
+      if (!response.ok) {
+        if (response.status === 503) {
+          setError('SMS is unavailable. Use email to receive your code.');
+        } else if (response.status === 400) {
+          setError('Phone OTP is Nepal-only. Enter +977… or use email.');
+        } else {
+          const payload = await response.json().catch(() => ({}));
+          setError(payload?.error || 'Could not send the code. Try again in a moment.');
+        }
+        return;
+      }
 
       if (typeof window !== 'undefined') {
-        sessionStorage.setItem('pending_id', normalized);
-        sessionStorage.setItem('pending_channel', 'email');
+        sessionStorage.setItem('pending_id', normalizedPhone);
+        window.location.href = '/verify';
       }
-
-      router.push('/verify');
     } catch (err: any) {
-      setError(err?.message || 'Could not send email code. Please try again.');
+      setError(err?.message || 'Could not send the code. Try again in a moment.');
     } finally {
-      setLoadingKey(null);
+      setLoading(false);
     }
   }
 
   return (
-    <main className="min-h-dvh bg-gradient-to-b from-slate-950 via-slate-900 to-black text-white">
-      <header className="px-6 md:px-12 pt-16 pb-10">
-        <span className="inline-block text-[10px] tracking-[0.2em] rounded-full border border-white/10 bg-white/5 px-2.5 py-1 text-sky-300/80">
-          GATISHILNEPAL.ORG
-        </span>
-        <h1 className="mt-4 text-4xl md:text-5xl font-black leading-tight">
-          Join the DAO Party of the Powerless
-        </h1>
-        <p className="mt-3 text-slate-300/90 max-w-2xl">
-          We’ll send a 6-digit code to confirm it’s you.
-        </p>
-      </header>
+    <main className="min-h-dvh bg-slate-950 text-white">
+      <div className="mx-auto flex min-h-dvh w-full max-w-2xl flex-col justify-center px-6 py-16">
+        <header className="mb-10 space-y-3">
+          <h1 className="text-3xl font-semibold md:text-4xl">Join Gatishil Nepal</h1>
+          <p className="text-base text-slate-300">
+            We’ll send a 6-digit code to confirm it’s you.
+          </p>
+        </header>
 
-      <section className="px-6 md:px-12 pb-20">
-        <div className="max-w-xl mx-auto rounded-3xl border border-white/10 bg-white/[0.04] backdrop-blur-xl p-6 shadow-[0_0_40px_-20px_rgba(255,255,255,0.4)]">
-          <div className="flex gap-2 rounded-xl bg-white/10 p-1 mb-6 text-sm font-semibold">
-            <button
-              type="button"
-              onClick={() => setTab('phone')}
-              className={`flex-1 px-4 py-2 rounded-lg transition ${tab === 'phone' ? 'bg-white text-black' : 'text-slate-300'} ${SMS_ENABLED ? '' : 'opacity-60'}`}
-            >
-              Phone
-            </button>
-            <button
-              type="button"
-              onClick={() => setTab('email')}
-              className={`flex-1 px-4 py-2 rounded-lg transition ${tab === 'email' ? 'bg-white text-black' : 'text-slate-300'}`}
-            >
-              Email
-            </button>
+        <form onSubmit={handleSubmit} className="space-y-6">
+          <div className="grid gap-4 md:grid-cols-2">
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-slate-200">Email</span>
+              <input
+                type="email"
+                inputMode="email"
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                className="w-full rounded-xl border border-white/15 bg-white px-4 py-3 text-base text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:bg-slate-900 dark:text-white dark:placeholder:text-slate-400"
+              />
+            </label>
+
+            <label className="flex flex-col gap-2">
+              <span className="text-sm font-medium text-slate-200">Phone</span>
+              <input
+                type="tel"
+                inputMode="tel"
+                autoComplete="tel"
+                value={phone}
+                onChange={(event) => setPhone(event.target.value)}
+                className="w-full rounded-xl border border-white/15 bg-white px-4 py-3 text-base text-slate-900 placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-emerald-400 dark:bg-slate-900 dark:text-white dark:placeholder:text-slate-400"
+              />
+              <span className="text-xs text-slate-400">Phone OTP works for Nepal (+977) only.</span>
+            </label>
           </div>
 
-          {tab === 'phone' && (
-            <form onSubmit={handlePhoneSubmit} className="space-y-4">
-              <div>
-                <label className="block text-xs text-slate-300/70 mb-2">Phone number</label>
-                <div className="flex gap-2">
-                  <select
-                    value={countryDial}
-                    onChange={(event) => setCountryDial(event.target.value)}
-                    className="rounded-xl bg-black/40 border border-white/15 px-3 py-2 text-sm"
-                    aria-label="Country dialing code"
-                  >
-                    {(COUNTRIES as { dial: string; flag: string; name: string }[]).map((c) => (
-                      <option key={c.dial} value={c.dial} className="bg-slate-900 text-white">
-                        {c.flag} {c.name} (+{c.dial})
-                      </option>
-                    ))}
-                  </select>
-                  <input
-                    value={phone}
-                    onChange={(event) => setPhone(event.target.value)}
-                    placeholder="98••••••••"
-                    inputMode="tel"
-                    autoComplete="tel"
-                    className="flex-1 rounded-xl bg-black/40 border border-white/15 px-3 py-2 text-base outline-none"
-                  />
-                </div>
-                {!SMS_ENABLED && (
-                  <p className="mt-2 text-xs text-amber-300/80">
-                    SMS is paused. Use email to receive your code.
-                  </p>
-                )}
-              </div>
+          {bothFilled && emailValid ? (
+            <p className="text-sm text-amber-300">Using email; clear it to use phone.</p>
+          ) : null}
 
-              <button
-                type="submit"
-                disabled={!SMS_ENABLED || loadingKey === 'phone'}
-                className="w-full px-4 py-3 rounded-2xl bg-emerald-400 text-black font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {loadingKey === 'phone' ? 'Sending…' : 'Send code'}
-              </button>
-            </form>
-          )}
+          {error ? <p className="text-sm text-rose-400">{error}</p> : null}
 
-          {tab === 'email' && (
-            <form onSubmit={handleEmailSubmit} className="space-y-4">
-              <div>
-                <label className="block text-xs text-slate-300/70 mb-2">Email address</label>
-                <input
-                  value={email}
-                  onChange={(event) => setEmail(event.target.value)}
-                  placeholder="you@example.com"
-                  type="email"
-                  autoComplete="email"
-                  className="w-full rounded-xl bg-black/40 border border-white/15 px-3 py-2 text-base outline-none"
-                />
-              </div>
-
-              <button
-                type="submit"
-                disabled={loadingKey === 'email'}
-                className="w-full px-4 py-3 rounded-2xl bg-amber-400 text-black font-semibold disabled:opacity-60 disabled:cursor-not-allowed"
-              >
-                {loadingKey === 'email' ? 'Sending…' : 'Email me the code'}
-              </button>
-            </form>
-          )}
-
-          {error && <p className="mt-4 text-xs text-rose-300">{error}</p>}
-
-          <p className="mt-6 text-[11px] text-slate-400">
-            We never reveal whether an address or number exists—generic errors protect your privacy.
-            {siteUrl ? (
-              <span className="block mt-1 text-slate-500">Requests originate from {siteUrl}.</span>
-            ) : null}
-          </p>
-        </div>
-      </section>
+          <button
+            type="submit"
+            disabled={loading || (!emailValid && !phoneValid)}
+            className="w-full rounded-xl bg-emerald-400 px-4 py-3 text-base font-semibold text-slate-900 transition disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? 'Sending…' : 'Send code'}
+          </button>
+        </form>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- update the join screen to support email sign-in or Nepal (+977) phone OTP with inline guidance and errors
- refresh the verification flow to auto-submit 6-digit codes, branch per identifier, and enforce resend/soft-lock rules
- implement the /api/otp/send endpoint to mint Supabase OTPs, persist hashed codes, and deliver SMS via Aakash

## Testing
- npm install *(fails: 403 Forbidden from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68f3173d6d50832c9bcdd8c1d996dc61