### PR TITLE
Restrict phone OTP sending to Nepal numbers

### DIFF
--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -110,6 +110,11 @@ function JoinClientBody() {
 
     try {
       const phone = e164(country.dial, phoneRaw);
+      if (!phone.startsWith('+977')) {
+        setErr('Phone OTP is Nepal-only. use email.');
+        setLoading(false);
+        return;
+      }
       const res = await safeFetch('/api/otp/send', {
         method: 'POST',
         headers: {


### PR DESCRIPTION
## Summary
- block phone OTP API calls for non-Nepal numbers on the join page
- keep existing email OTP flow while adding inline guidance for unsupported phone numbers

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f328e6ed48832c8f6538a28854f761