### PR TITLE
Simplify Aakash SMS configuration

### DIFF
--- a/app/api/otp/send/route.ts
+++ b/app/api/otp/send/route.ts
@@ -72,12 +72,10 @@ async function discardOtp(id?: number) {
 }
 
 async function sendAakashSms(providerPhone: string, text: string) {
-  const base = env('AAKASH_SMS_BASE_URL').replace(/\/$/, '');
   const apiKey = env('AAKASH_SMS_API_KEY');
-  const sender = env('AAKASH_SMS_SENDER');
 
-  const payload = { from: sender, to: providerPhone, text };
-  const res = await fetch(`${base}/sms/send`, {
+  const payload = { to: providerPhone, text };
+  const res = await fetch('https://sms.aakashsms.com/v2/sms/send', {
     method: 'POST',
     headers: {
       'content-type': 'application/json',


### PR DESCRIPTION
## Summary
- update the OTP SMS sender to use the fixed Aakash endpoint
- drop the requirement for additional Aakash env vars so only the API key is needed

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f346bf2fcc832ca0d8607eabc9c08d