### PR TITLE
Restore Aakash SMS OTP route

### DIFF
--- a/sql/otp_table.sql
+++ b/sql/otp_table.sql
@@ -4,6 +4,7 @@ create table if not exists public.otps (
   id bigserial primary key,
   phone text not null,
   code_hash text not null,
+  expires_at timestamptz not null,
   created_at timestamptz not null default now(),
   used_at timestamptz,
   meta jsonb default '{}'


### PR DESCRIPTION
## Summary
- update the OTP SMS sender to use the fixed Aakash endpoint while requiring only the API key
- drop the requirement for additional Aakash env vars so only the API key is needed
- ensure the SMS send route persists hashed OTPs with expirations, returns 503 when the provider fails, and align verification with the new expiry column

## Testing
- npm run lint *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f346bf2fcc832ca0d8607eabc9c08d