### PR TITLE
Fix legacy Aakash SMS integration for OTP send

### DIFF
--- a/app/api/otp/send/route.ts
+++ b/app/api/otp/send/route.ts
@@ -8,6 +8,7 @@ export const dynamic = 'force-dynamic';
 
 const NEPAL_MOBILE = /^\+97798\d{8}$/;
 const OTP_TTL_MS = 5 * 60 * 1000;
+const AAKASH_ENDPOINT = 'https://sms.aakashsms.com/sms/v3/send';
 
 function normalizePhone(value: string) {
   const trimmed = value.trim();
@@ -25,16 +26,13 @@ function normalizePhone(value: string) {
   return `+${digits}`;
 }
 
-function providerFormat(phone: string) {
-  return phone.slice(1);
-}
+function fetchWithTimeout(url: string, options: RequestInit = {}, timeoutMs = 6000) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
 
-function env(key: string) {
-  const value = process.env[key];
-  if (!value) {
-    throw new Error(`Missing env: ${key}`);
-  }
-  return value;
+  return fetch(url, { ...options, signal: controller.signal }).finally(() => {
+    clearTimeout(timer);
+  });
 }
 
 function generateOtp() {
@@ -72,65 +70,157 @@ async function discardOtp(id?: number) {
   await supabase.from('otps').delete().eq('id', id);
 }
 
-async function sendAakashSms(providerPhone: string, text: string) {
-  const apiKey = env('AAKASH_SMS_API_KEY');
+async function sendAakashSms(apiKey: string, normalizedPhone: string, text: string) {
+  const e164NoPlus = normalizedPhone.slice(1);
+  const national = e164NoPlus.replace(/^977/, '');
 
-  const payload = { to: providerPhone, text };
-  const res = await fetch('https://sms.aakashsms.com/v2/sms/send', {
-    method: 'POST',
-    headers: {
-      'content-type': 'application/json',
-      authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify(payload),
-    cache: 'no-store',
-  });
+  type AttemptStatus = number | string | undefined;
 
-  let body: any = null;
-  try {
-    body = await res.json();
-  } catch {
-    body = await res.text().catch(() => '');
-  }
+  const attempt = async (to: string) => {
+    try {
+      const params = new URLSearchParams({ auth_token: apiKey, to, text });
+      const res = await fetchWithTimeout(
+        AAKASH_ENDPOINT,
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/x-www-form-urlencoded' },
+          body: params,
+          cache: 'no-store',
+        },
+        6000,
+      );
 
-  const success =
-    res.ok &&
-    ((body && typeof body === 'object' &&
-      (body.success === true ||
-        body.success === 'true' ||
-        (typeof body.status === 'string' && body.status.toLowerCase() === 'success') ||
-        (typeof body.code === 'number' && body.code >= 200 && body.code < 300))) ||
-      body === '' || body === null);
+      const contentType = res.headers.get('content-type')?.toLowerCase() ?? '';
+      let parsed: any = null;
+      let rawText = '';
 
-  const logBody =
-    body && typeof body === 'object'
-      ? {
-          success: body.success,
-          status: body.status,
-          code: body.code,
-          message: body.message || body.error || body.reason,
+      if (contentType.includes('application/json')) {
+        parsed = await res.json().catch(() => null);
+        if (parsed !== null && parsed !== undefined) {
+          rawText = JSON.stringify(parsed);
+        } else {
+          rawText = await res.text().catch(() => '');
         }
-      : body;
+      } else {
+        rawText = await res.text().catch(() => '');
+      }
 
-  const logPayload = {
-    status: res.status,
-    ok: success,
-    body: logBody,
+      const success = isProviderSuccess(res, parsed, rawText);
+      const bodyForLog = rawText;
+
+      return {
+        ok: success,
+        status: res.status as AttemptStatus,
+        body: bodyForLog,
+      };
+    } catch (error: any) {
+      const status: AttemptStatus = error?.name === 'AbortError' ? 'timeout' : 'error';
+      const message = typeof error?.message === 'string' ? error.message : '';
+      return {
+        ok: false,
+        status,
+        body: message,
+      };
+    }
   };
 
-  // eslint-disable-next-line no-console
-  console.info('Aakash SMS response', logPayload);
+  const first = await attempt(e164NoPlus);
+  let second: { ok: boolean; status: AttemptStatus; body: string } | null = null;
 
-  if (!success) {
-    const msg =
-      (body && typeof body === 'object' && (body.message || body.error || body.reason)) ||
-      (typeof body === 'string' && body) ||
-      `Aakash SMS failed (${res.status})`;
-    const err: any = new Error(msg);
-    err.status = res.status;
-    err.provider = logPayload;
-    throw err;
+  if (!first.ok && national !== e164NoPlus) {
+    second = await attempt(national);
   }
+
+  const status1 = first.status;
+  const status2 = second ? second.status : national === e164NoPlus ? 'duplicate' : 'skipped';
+
+  // eslint-disable-next-line no-console
+  console.log('[otp/send] try:e164,national status:', status1, status2);
+
+  if (first.ok || second?.ok) {
+    return;
+  }
+
+  const failure = second ?? first;
+  const status = failure.status ?? 'unknown';
+  const body = failure.body ?? '';
+
+  // eslint-disable-next-line no-console
+  console.error('[otp/send] provider_error:', status, body.slice(0, 180));
+
+  const error = new Error('Aakash SMS failed');
+  (error as any).status = status;
+  throw error;
+}
+
+function isProviderSuccess(res: Response, body: any, rawText: string) {
+  if (!res.ok) {
+    return false;
+  }
+
+  if (body && typeof body === 'object') {
+    if ('error' in body) {
+      const value = body.error;
+      if (
+        value === true ||
+        value === 'true' ||
+        (typeof value === 'number' && value !== 0) ||
+        (typeof value === 'string' && value.trim() !== '' && value.trim() !== '0' && value.trim().toLowerCase() !== 'false')
+      ) {
+        return false;
+      }
+    }
+
+    if ('success' in body) {
+      const value = body.success;
+      if (!successLike(value)) {
+        return false;
+      }
+    }
+
+    if ('status' in body) {
+      const status = String(body.status).toLowerCase();
+      if (status && status !== 'success' && status !== 'ok') {
+        return false;
+      }
+    }
+
+    if ('code' in body) {
+      const code = Number(body.code);
+      if (!Number.isNaN(code) && (code < 200 || code >= 300)) {
+        return false;
+      }
+    }
+
+    if ('response_code' in body) {
+      const code = Number(body.response_code);
+      if (!Number.isNaN(code) && (code < 200 || code >= 300)) {
+        return false;
+      }
+    }
+  }
+
+  if (!body && typeof rawText === 'string') {
+    const trimmed = rawText.trim();
+    if (!trimmed) {
+      return true;
+    }
+    if (/error/i.test(trimmed) && !/success|sent|queued/i.test(trimmed)) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+function successLike(value: unknown) {
+  return (
+    value === true ||
+    value === 'true' ||
+    value === 1 ||
+    value === '1' ||
+    (typeof value === 'string' && value.toLowerCase() === 'success')
+  );
 }
 
 function okResponse() {
@@ -191,16 +281,19 @@ export async function POST(req: Request) {
     return errorResponse('Could not send OTP. Please try again.', 500);
   }
 
-  const providerPhone = providerFormat(normalized);
   const text = `Your Gatishil Nepal code is ${code}. It expires in 5 minutes.`;
+  const apiKey = process.env.AAKASH_SMS_API_KEY;
+
+  if (!apiKey) {
+    await discardOtp(persistedId).catch(() => {});
+    return errorResponse('SMS is temporarily unavailable. Please use email.', 503);
+  }
 
   try {
-    await sendAakashSms(providerPhone, text);
+    await sendAakashSms(apiKey, normalized, text);
     return okResponse();
   } catch (error) {
     await discardOtp(persistedId).catch(() => {});
-    // eslint-disable-next-line no-console
-    console.error('Aakash SMS failed', error);
     return errorResponse('Aakash SMS failed', 503);
   }
 }


### PR DESCRIPTION
## Summary
- restore the legacy Aakash SMS v3 POST request with auth_token form payload
- add a 6s timeout, dual-format retry, and minimal diagnostics around the provider call
- assert the legacy API key env before sending and clean up OTP rows on SMS failures

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f34b0d5070832c95f3a3e456976ec3