### PR TITLE
Add dedicated SMS OTP verification flow

### DIFF
--- a/app/api/otp/verify/route.ts
+++ b/app/api/otp/verify/route.ts
@@ -1,3 +1,196 @@
-// app/api/otp/verify/route.ts
-// Back-compat shim: reuse the unified verifier at /api/otp
-export { POST } from '../route';
+import { NextResponse } from 'next/server';
+import { createHash } from 'node:crypto';
+import { getAdminSupabase } from '@/lib/admin';
+import { NEPAL_MOBILE, normalizeOtpPhone } from '@/lib/auth/phone';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function safeString(value: unknown) {
+  if (typeof value === 'string') return value;
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+function badRequest(message: string) {
+  return NextResponse.json({ ok: false, message }, { status: 400 });
+}
+
+function serviceError(message: string) {
+  return NextResponse.json({ ok: false, message }, { status: 503 });
+}
+
+function hashCode(code: string) {
+  return createHash('sha256').update(code).digest('hex');
+}
+
+export async function POST(req: Request) {
+  let phone = '';
+  let code = '';
+
+  try {
+    const body = await req.json().catch(() => null);
+    if (body && typeof body === 'object') {
+      phone = safeString((body as any).phone ?? '');
+      code = safeString((body as any).code ?? '');
+    }
+  } catch {
+    // ignore malformed JSON; we'll validate below
+  }
+
+  phone = phone.trim();
+  code = code.trim();
+
+  if (!phone) {
+    return badRequest('Enter your phone number.');
+  }
+
+  const normalized = normalizeOtpPhone(phone);
+
+  if (!normalized) {
+    return badRequest('Enter a valid phone number.');
+  }
+
+  if (!normalized.startsWith('+977')) {
+    return badRequest('Phone OTP is Nepal-only. use email.');
+  }
+
+  if (!NEPAL_MOBILE.test(normalized)) {
+    return badRequest('Enter a valid phone number.');
+  }
+
+  if (!code) {
+    return badRequest('Enter the 6-digit code.');
+  }
+
+  if (!/^\d{6}$/.test(code)) {
+    return badRequest('Enter the 6-digit code.');
+  }
+
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    return serviceError('Auth unavailable. Use email.');
+  }
+
+  const providerPhone = normalized;
+  const hashedCode = hashCode(code).toLowerCase();
+
+  try {
+    const supabaseAdmin = getAdminSupabase();
+
+    const { data: otpRow, error: selectError } = await supabaseAdmin
+      .from('otps')
+      .select('id, code_hash, attempts')
+      .eq('phone', providerPhone)
+      .is('consumed_at', null)
+      .gt('expires_at', new Date().toISOString())
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (selectError) {
+      throw selectError;
+    }
+
+    if (!otpRow) {
+      return badRequest('Code expired or not found.');
+    }
+
+    const storedHash = typeof otpRow.code_hash === 'string' ? otpRow.code_hash.toLowerCase() : '';
+    const matches = storedHash === hashedCode;
+
+    if (!matches) {
+      await supabaseAdmin
+        .from('otps')
+        .update({ attempts: (otpRow.attempts ?? 0) + 1 })
+        .eq('id', otpRow.id)
+        .catch(() => {});
+
+      return badRequest('Invalid code.');
+    }
+
+    const consumedAt = new Date().toISOString();
+    const { error: consumeError } = await supabaseAdmin
+      .from('otps')
+      .update({ consumed_at: consumedAt })
+      .eq('id', otpRow.id)
+      .is('consumed_at', null);
+
+    if (consumeError) {
+      throw consumeError;
+    }
+
+    const adminAuth = supabaseAdmin.auth.admin as any;
+    if (!adminAuth || typeof adminAuth.createSession !== 'function') {
+      return serviceError('Auth unavailable. Use email.');
+    }
+
+    let user: any = null;
+
+    if (typeof adminAuth.listUsers === 'function') {
+      const listed = await adminAuth.listUsers({ page: 1, perPage: 200 });
+      if (listed?.error) {
+        throw new Error(listed.error.message || 'User lookup failed');
+      }
+      const users: any[] = listed?.data?.users ?? listed?.users ?? [];
+      user = users.find((u: any) => u?.phone === normalized) ?? null;
+    }
+
+    if (!user) {
+      const created = await adminAuth.createUser({
+        phone: normalized,
+        phone_confirm: true,
+        user_metadata: { phone_verified: true },
+      });
+
+      if (created?.error && !/already exists|registered/i.test(created.error.message ?? '')) {
+        throw new Error(created.error.message || 'Could not create user');
+      }
+
+      user = created?.data?.user ?? created?.user ?? null;
+
+      if (!user && typeof adminAuth.listUsers === 'function') {
+        const listed = await adminAuth.listUsers({ page: 1, perPage: 200 });
+        if (listed?.error) {
+          throw new Error(listed.error.message || 'User lookup failed');
+        }
+        const users: any[] = listed?.data?.users ?? listed?.users ?? [];
+        user = users.find((u: any) => u?.phone === normalized) ?? null;
+      }
+    }
+
+    if (!user?.id) {
+      return serviceError('Auth unavailable. Use email.');
+    }
+
+    const { data: sessionData, error: sessionError } = await adminAuth.createSession({ user_id: user.id });
+
+    if (sessionError || !sessionData?.session) {
+      return serviceError('Could not start session.');
+    }
+
+    const session = sessionData.session;
+
+    const { error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .upsert({ id: user.id, phone: normalized }, { onConflict: 'id' });
+
+    if (profileError) {
+      // eslint-disable-next-line no-console
+      console.warn('[otp/verify] Failed to upsert profile phone', profileError);
+    }
+
+    return NextResponse.json(
+      {
+        ok: true,
+        access_token: session.access_token,
+        refresh_token: session.refresh_token,
+        user: session.user ?? user,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[otp/verify] unexpected error', error);
+    return serviceError('Verification is temporarily unavailable. Please try again.');
+  }
+}

--- a/lib/auth/phone.ts
+++ b/lib/auth/phone.ts
@@ -1,0 +1,17 @@
+export const NEPAL_MOBILE = /^\+97798\d{8}$/;
+
+export function normalizeOtpPhone(value: string) {
+  const trimmed = value.trim();
+  if (!trimmed) return '';
+  const raw = trimmed.replace(/[\s-]/g, '');
+  if (!raw) return '';
+  const prefixed = raw.startsWith('+') ? raw : `+${raw}`;
+  const digits = prefixed.replace(/^\+/, '');
+  if (!/^\d+$/.test(digits)) {
+    return '';
+  }
+  if (!prefixed.startsWith('+977')) {
+    return prefixed;
+  }
+  return `+${digits}`;
+}


### PR DESCRIPTION
## Summary
- add a node runtime /api/otp/verify handler that validates hashed OTP codes, creates Supabase sessions, and upserts profile phone numbers
- extract the shared phone normalizer so the send and verify routes format numbers the same way
- update the join client to call the new verify endpoint, set the Supabase session, and redirect to the dashboard

## Testing
- npm run lint -- --file app/api/otp/verify/route.ts --file app/api/otp/send/route.ts --file app/join/JoinClient.tsx --file lib/auth/phone.ts *(fails: next not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f34dd7f14c832cb5d3d8c224af4ced