### PR TITLE
Enforce canonical Nepal phone OTP handling

### DIFF
--- a/lib/phone/nepal.ts
+++ b/lib/phone/nepal.ts
@@ -1,4 +1,4 @@
-export function normalizeNepalToDB(input: string | undefined | null) {
+export function normalizeNepalToDB(input?: string | null) {
   const raw = String(input ?? '').trim().replace(/[\s-]/g, '');
   const plus = raw.startsWith('+') ? raw : `+${raw}`;
   if (!plus.startsWith('+977')) return null;

--- a/supabase/migrations/20251021_lock_otps_phone.sql
+++ b/supabase/migrations/20251021_lock_otps_phone.sql
@@ -1,0 +1,20 @@
+-- Inspect current constraint (prints to results)
+select conname, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.otps'::regclass;
+
+-- Replace with canonical rule (exactly 13 digits: 977 + 10 starting with 9)
+alter table public.otps drop constraint if exists otps_phone_check;
+alter table public.otps add constraint otps_phone_check
+  check ( phone ~ '^9779[0-9]{9}$' );
+
+-- Purge legacy rows that would violate the new rule
+delete from public.otps where phone !~ '^9779[0-9]{9}$';
+
+-- Sanity proof in DB itself
+select '977981234567' ~ '^9779[0-9]{9}$' as should_be_true,
+       '97781234567'  ~ '^9779[0-9]{9}$' as should_be_false,
+       '+977981234567' ~ '^9779[0-9]{9}$' as should_be_false;
+
+-- Reload PostgREST cache
+notify pgrst, 'reload schema';


### PR DESCRIPTION
## Summary
- force the Supabase admin client to the public schema and reuse a canonical Nepal phone normalizer in the OTP send/verify routes
- add safe request parsing, defensive logging, and canonical phone inserts when creating SMS OTPs
- add a migration that enforces the otps.phone regex constraint and cleans up non-conforming data

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f35ea7ed84832cb13a919546563f03