### PR TITLE
Ensure Supabase SSR reads modern and legacy cookies

### DIFF
--- a/lib/supabase/browser.ts
+++ b/lib/supabase/browser.ts
@@ -1,32 +1,61 @@
-// lib/supabase/browser.ts
 import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
-let _client: ReturnType<typeof createBrowserClient> | null = null;
+let singleton: SupabaseClient | null = null;
+let isSyncing = false;
 
-export function getSupabaseBrowser() {
-  if (_client) return _client;
-
-  _client = createBrowserClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-  );
-
-  const sync = async () => {
-    const { data: { session } } = await _client!.auth.getSession();
+const syncSessionCookies = async (client: SupabaseClient) => {
+  if (isSyncing) return;
+  isSyncing = true;
+  try {
+    const {
+      data: { session },
+    } = await client.auth.getSession();
     const access_token = session?.access_token ?? null;
     const refresh_token = session?.refresh_token ?? null;
     if (!access_token) return;
+
     await fetch('/api/auth/sync', {
       method: 'POST',
       credentials: 'include',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ access_token, refresh_token }),
-    }).catch(() => {});
-  };
+    });
+  } catch {
+    // Ignore network failures — cookies simply won't sync this cycle.
+  } finally {
+    isSyncing = false;
+  }
+};
 
-  _client.auth.onAuthStateChange((event) => {
-    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') sync();
+export function getSupabaseBrowser(): SupabaseClient {
+  if (singleton) return singleton;
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anon) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
+  }
+
+  singleton = createBrowserClient(url, anon, {
+    auth: {
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+      storageKey: 'gatishil.auth.token',
+    },
   });
 
-  return _client;
+  void syncSessionCookies(singleton);
+
+  singleton.auth.onAuthStateChange(event => {
+    if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+      void syncSessionCookies(singleton!);
+    }
+  });
+
+  return singleton;
 }
+
+export const supabase = getSupabaseBrowser();

--- a/lib/supabaseBrowser.ts
+++ b/lib/supabaseBrowser.ts
@@ -1,2 +1,6 @@
+import { getSupabaseBrowser } from '@/lib/supabase/browser';
+
 // Compatibility re-export for older imports
-export { supabase as supabaseBrowser, getBrowserSupabase } from '@/lib/supabase/browser';
+export { supabase as supabaseBrowser, getSupabaseBrowser } from '@/lib/supabase/browser';
+
+export const getBrowserSupabase = getSupabaseBrowser;

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,35 +1,7 @@
 "use client";
 
-import { createBrowserClient } from '@supabase/ssr';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase, getSupabaseBrowser } from '@/lib/supabase/browser';
 
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string | undefined;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string | undefined;
+export { supabase, getSupabaseBrowser };
 
-if (!url || !anon) {
-  // Fail fast during build if envs are missing
-  throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
-}
-
-let browserClient: SupabaseClient | undefined;
-
-const getBrowserSingleton = (): SupabaseClient => {
-  if (!browserClient) {
-    browserClient = createBrowserClient(url, anon, {
-      auth: {
-        persistSession: true,
-        autoRefreshToken: true,
-        detectSessionInUrl: true,
-        storageKey: 'gatishil.auth.token',
-      },
-    });
-  }
-  return browserClient;
-};
-
-// Browser-safe singleton client
-export const supabase = getBrowserSingleton();
-
-// Alias names to satisfy various imports across the app
-export const getSupabaseBrowser = () => getBrowserSingleton();
-export const getSupabaseBrowserClient = () => getBrowserSingleton();
+export const getSupabaseBrowserClient = getSupabaseBrowser;

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -8,12 +8,43 @@ if (!url || !anon) {
   throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
 }
 
+type LegacyTokenPayload = {
+  access_token?: string;
+  refresh_token?: string;
+};
+
+const getLegacyTokens = (raw: string | undefined | null): LegacyTokenPayload | null => {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as LegacyTokenPayload;
+    if (typeof parsed?.access_token === 'string' && parsed.access_token.length > 0) {
+      return parsed;
+    }
+  } catch {
+    // Ignore JSON parse errors
+  }
+  return null;
+};
+
 export function getServerSupabase() {
   const cookieStore = cookies();
+  const legacy = getLegacyTokens(cookieStore.get('supabase-auth-token')?.value);
+
   return createServerClient(url, anon, {
     cookies: {
       get(name: string) {
-        return cookieStore.get(name)?.value;
+        const direct = cookieStore.get(name)?.value;
+        if (direct) return direct;
+
+        if (legacy) {
+          if (name === 'sb-access-token') {
+            return legacy.access_token ?? undefined;
+          }
+          if (name === 'sb-refresh-token') {
+            return legacy.refresh_token ?? undefined;
+          }
+        }
+        return undefined;
       },
       set(name: string, value: string, options: CookieOptions) {
         cookieStore.set({ name, value, ...options });


### PR DESCRIPTION
## Summary
- update the server-side Supabase client to fall back to legacy cookie values when modern sb-* tokens are missing
- centralize the browser Supabase client creation and session syncing logic so the SSR cookies stay up to date
- keep compatibility exports for legacy imports while pointing them to the new browser client helper

## Testing
- npm run lint *(fails: `next` binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f4a381a13c832ca67d5263356da768