### PR TITLE
Add auth control tower documentation

### DIFF
--- a/AUTH_CONTROL_TOWER.md
+++ b/AUTH_CONTROL_TOWER.md
@@ -1,0 +1,167 @@
+# 🧭 Gatishil Nepal Auth Control Tower
+
+This control tower distills every moving part of Gatishil Nepal’s authentication story — from the first OTP request on `/join` to the cookies, local PIN, and dashboard session checks. Use it as a single-page radar for code owners, incident responders, and onboarding engineers.
+
+## Auth Surface Inventory
+
+### Routes & Pages
+| File | Purpose | Key exports / functions | Invoked from | Redirect behavior |
+| --- | --- | --- | --- | --- |
+| `app/join/page.tsx` | Server entry that mounts the client-only join experience. | Default page component. | App Router for `/join`. | Defers to client logic for redirects. |
+| `app/join/JoinClient.tsx` | Implements dual email/phone OTP flows, message UI, and redirect-on-session logic. | `JoinClient`, `sendOtp`, `verifyOtp`, `sendEmailOtp`, `verifyEmailOtp`. | Rendered by `/join`; calls `/api/otp/*` and Supabase browser client. | Redirects signed-in users to `/onboard?src=join`; phone verify expects access/refresh tokens then pushes `/dashboard`; email verify pushes `/onboard`. |
+| `app/verify/page.tsx` | Thin wrapper for legacy verify client. | Default page component. | `/verify`. | None. |
+| `app/verify/VerifyClient.tsx` | Legacy OTP confirmation screen using Supabase verify APIs and sessionStorage hints. | `VerifyClient`, `verify`, `resend`. | `/verify`; triggered after storing `pending_id` elsewhere. | On success sets `window.location` to `/onboard?src=join`. |
+| `app/onboard/page.tsx` | Suspense shell around the onboarding flow. | Default page component with dynamic rendering. | `/onboard`. | None; onboarding flow drives navigation. |
+| `components/OnboardingFlow.tsx` | Orchestrates multi-step onboarding, Supabase code exchange, and final Trust step. | `OnboardingFlow`. | Used by `/onboard`. | Exchanges `code` params for sessions; pushes between steps and finally `/dashboard`. |
+| `components/onboard/NameFaceStep.jsx` | Captures name + selfie, uploads to Supabase Storage, and upserts profile. | `NameFaceStep`, `uploadAvatar`. | Loaded dynamically during onboarding. | Blocks progression until name + photo saved; stays on step otherwise. |
+| `components/onboard/RootsStep.jsx` | Stores diaspora / homeland metadata in `profiles.roots_json`. | `RootsStep`. | Onboarding flow. | Prevents next step until selection saved; no external redirect. |
+| `components/AtmaDisha/AtmaDisha.jsx` | Collects occupation, skills, passions, compassion, and vision. | `AtmaDisha`, `persist`. | Onboarding flow. | Calls `onDone` (→ Trust step) after saving; no direct navigation. |
+| `components/onboard/TrustStep.jsx` | Final onboarding gate for PIN creation, cookie sync, and dashboard hop. | `TrustStep`, `savePin`, `syncToServerCookies`. | Onboarding flow. | After PIN save or reuse, syncs cookies then replaces to `/dashboard`. |
+| `app/login/page.tsx` | Server wrapper that short-circuits logged-in visitors and renders login UI. | `LoginPage`, `safeNext`. | `/login`. | Redirects existing sessions to sanitized `next` or `/dashboard`. |
+| `app/login/LoginClient.tsx` | Multifaceted login client (password, email OTP, magic link). | `LoginClient`, `onPasswordLogin`, `onOtpLogin`, `onMagicLink`. | Rendered by `/login`. | Pushes to validated `next` on success. |
+| `app/auth/callback/page.tsx` | Server shell for OAuth/OTP callback. | Default page component. | `/auth/callback`. | None. |
+| `app/auth/callback/Client.tsx` | Exchanges Supabase PKCE or token hash and syncs cookies before redirect. | `Client`. | Mounted on `/auth/callback`. | Redirects to `next` (default `/onboard?src=join`) after session sync. |
+| `app/dashboard/page.tsx` | Server-rendered member console requiring Supabase session. | `DashboardPage`. | `/dashboard`. | Redirects anonymous users to `/login?next=/dashboard`. |
+| `middleware.ts` | Global guard that whitelists public auth routes and protects `/dashboard`. | `middleware`. | Runs on all edge requests. | Redirects missing sessions hitting `/dashboard` to `/login?next=…`. |
+
+### API Routes
+| File | Purpose | Key exports / functions | Called by | Redirect / Side effects |
+| --- | --- | --- | --- | --- |
+| `app/api/otp/send/route.ts` | Issues OTP via Supabase email or Aakash SMS and stores codes. | `POST` handler plus helper send/save functions. | `/join` client (phone/email tabs). | Responds with `{ ok, message }`; no redirect, but populates Supabase `otp_store` and triggers SMS/email. |
+| `app/api/otp/verify/route.ts` | Validates phone codes, rate-limits attempts, and signs in with service role. | `POST` handler. | `/join` phone verify flow; `verifyOtpAndSync`. | Returns `{ ok, user }` on success — caller must establish session. |
+| `app/api/auth/sync/route.ts` | Writes Supabase access/refresh tokens into secure cookies (plus legacy JSON). | `OPTIONS`, `POST`. | Login flows, TrustStep, Supabase browser sync. | No redirect; response `{ ok: true }` with Set-Cookie. |
+
+### Shared Libraries & Utilities
+| File | Purpose | Key exports | Consumed by | Notes |
+| --- | --- | --- | --- | --- |
+| `lib/supabaseClient.ts` | Client-only re-export of Supabase browser singleton. | `supabase`, `getSupabaseBrowser`. | Most client flows (Join, onboarding, login). | Wraps `lib/supabase/browser`. |
+| `lib/supabase/browser.ts` | Creates singleton browser client and mirrors tokens into cookies. | `getSupabaseBrowser`, `supabase`. | Login & onboarding UIs. | Syncs via `/api/auth/sync` on sign-in/refresh. |
+| `lib/supabase/server.ts` | SSR Supabase client respecting modern & legacy cookies. | `getSupabaseServer`. | `/dashboard`. | Reads `sb-*` cookies, falls back to legacy JSON. |
+| `lib/supabaseServer.ts` | Older server helper with writeable cookies. | `getServerSupabase`. | `/login`. | Supports legacy cookie decoding. |
+| `lib/auth/verifyOtpClient.ts` | Browser helper that verifies OTP then syncs cookies. | `verifyOtpAndSync`. | `/login`, `/auth/callback`. | Waits for session, posts to `/api/auth/sync`. |
+| `lib/auth/waitForSession.ts` | Polls Supabase until a session appears. | `waitForSession`. | `verifyOtpAndSync`, `/join` email flow. | Returns tokens for cookie sync. |
+| `lib/auth/next.ts` | Sanitizes `next` redirect values. | `getValidatedNext`. | `/login` client. | Blocks external redirects. |
+| `lib/auth/validate.ts` | Shared identifier helpers. | `isPhone`, `isEmail`, `maskIdentifier`. | `/verify` client, other validators. | Masks for UI. |
+| `lib/constants/auth.ts` | OTP timing constants. | `OTP_TTL_SECONDS`, etc. | `/verify`. | 5-minute TTL, resend cooldown. |
+| `lib/ui/OtpInput.tsx` | Reusable 6-digit OTP input. | `OtpInput`. | `/verify`. | Auto-focus & paste-friendly. |
+| `lib/localPin.ts` | Local PIN storage using WebCrypto + localStorage. | `createLocalPin`, `hasLocalPin`, `unlockWithPin`. | TrustStep. | Stores secrets under `gn.local.*`. |
+| `lib/webauthn.ts` | Passkey helpers (cookie + payload normalization). | `deriveRpID`, `setChallengeCookie`, etc. | Future `/security` and passkey flows. | No `/api/webauthn/*` handlers present. |
+
+### Middleware, Hooks, and Extras
+| File | Purpose | Key exports | Consumed by | Redirect behavior |
+| --- | --- | --- | --- | --- |
+| `hooks/useEnsureProfile.ts` | Creates minimal profile row after login (unused). | `useEnsureProfile`. | Not referenced currently. | n/a. |
+| `app/status/page.tsx` (auth portion) | Uses `getSupabaseBrowserClient` to gate stats. | Page component. | `/status`. | None (informational). |
+
+## Visual Panels
+
+### Panel 1: Route-Guard Matrix
+
+| Route | No Session | Session | Onboarding Done | PIN Set | Trusted Device |
+| --- | --- | --- | --- | --- | --- |
+| `/join` | allow | → `/onboard?src=join` (client redirect) | → `/onboard?src=join` (no dashboard fast-path) | → `/onboard?src=join` after PIN creation elsewhere | allow (PIN check is local only) |
+| `/verify` | allow | allow (no guard) | allow | allow | allow |
+| `/onboard` | allow (API calls will fail without session) | allow | allow (no completion check) | allow | allow |
+| `/login` | allow | allow (server redirect only if session detected) | allow | allow | allow |
+| `/dashboard` | → `/login?next=/dashboard` | allow | allow (shows partial profile) | allow | allow |
+
+### Panel 2: Redirect Truth Table
+
+| User action | Has session? | Identifier status (+977 / email) | Code valid? | Attempts remaining | PIN / device trust | Cookies synced? |
+| --- | --- | --- | --- | --- | --- | --- |
+| Send phone OTP (`/join`) | Existing session triggers instant move to `/onboard?src=join`. | `+977` → success toast, stores `otpSentTo`; non-`+977` → error toast, no API call. | n/a | n/a | n/a | No cookies touched. |
+| Verify phone OTP (`/join`) | Requires fresh session from API response (otherwise throws). | Phone only. | Match expected → tries to set Supabase session then replace `/dashboard`; mismatch → error toast, stay on `/join`. | After 5 failures API locks for 2 min. | n/a | Depends on API returning tokens; without them session sync fails. |
+| Send email OTP (`/join`) | Existing session rerouted before action. | Email only. | n/a | n/a | n/a | Supabase sends OTP, client shows success toast. |
+| Verify email OTP (`/join`) | Waits for Supabase session after `verifyOtp`; if missing, shows error. | Email only. | Valid code → replace `/onboard?src=otp`; invalid → error toast. | Supabase handles attempts internally. | n/a | Does **not** call `/api/auth/sync`; relies on Supabase local storage. |
+| Legacy verify submit (`/verify`) | Independent of current session. | Email or phone from `pending_id`. | Valid → `window.location` `/onboard?src=join`; invalid → decrements tries. | Local counter enforces 5 attempts. | n/a | No cookie sync. |
+| Name & face “Continue” | Requires Supabase session to upload; absence throws “No session”. | n/a | n/a | n/a | n/a | Successful save leaves user on `/onboard?step=roots`. |
+| Roots “Continue” | Needs Supabase session for profile update. | Chooses Nepal/Abroad meta. | n/a | n/a | n/a | Remains on `/onboard`, pushes to `step=atmadisha` on save. |
+| Ātma Diśā finish | Session required to persist profile traits. | n/a | n/a | n/a | n/a | Calls `onDone` to enter Trust step; no redirect. |
+| Save PIN (`TrustStep`) | Supabase session required for cookie sync. | n/a | n/a | n/a | Stores encrypted PIN in `localStorage`; sets toast. | Calls `/api/auth/sync`, then `replace('/dashboard')`. |
+| Keep existing PIN | n/a | n/a | n/a | n/a | Requires `hasLocalPin()` true. | Syncs cookies, replaces `/dashboard`. |
+| Password login (`/login`) | n/a | Email/password. | n/a | n/a | n/a | On success posts tokens to `/api/auth/sync`, `push(next)`. |
+| Magic link request (`/login`) | n/a | Email. | n/a | n/a | n/a | Supabase sends link; UI shows “Magic link sent” toast. |
+| OTP login (`/login`) | n/a | Email + code. | Valid → `verifyOtpAndSync` → `push(next)`; invalid → error toast. | Depends on `/api/otp/verify` rate limits. | n/a | Always syncs cookies via helper. |
+| `/auth/callback` exchange | If already signed in, goes straight to `next`. | PKCE `code` or OTP `token_hash`. | Valid → session + cookie sync, redirect to `next`; invalid → error with CTA back to login. | n/a | n/a | Calls `/api/auth/sync` after obtaining tokens. |
+
+### Panel 3: State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> ANON
+    ANON --> OTP_SENT: /join “Send OTP”
+    OTP_SENT --> OTP_SENT: Resend (cooldown, same page)
+    OTP_SENT --> OTP_VERIFIED: /join or /verify “Verify code” \n(guard: Supabase OK + API ok)
+    OTP_VERIFIED --> ONBOARDING: Router.replace /onboard*
+    OTP_VERIFIED --> ANON: Verification error \n(guard: invalid code / lock)
+    ONBOARDING --> PIN_SET: TrustStep save PIN \n(guard: Supabase session)
+    ONBOARDING --> OTP_SENT: Logout/backtrack triggers Join again
+    PIN_SET --> TRUSTED: LocalStorage stores `gn.local.secret`
+    TRUSTED --> DASHBOARD: Sync cookies → replace('/dashboard')
+    DASHBOARD --> ANON: Logout (clears session/cookies)
+```
+
+### Panel 4: Request Swimlane
+
+```mermaid
+sequenceDiagram
+    participant B as Browser UI
+    participant API as Next API Routes
+    participant SB as Supabase Auth
+    participant ST as LocalStorage / Cookies
+
+    B->>API: POST /api/otp/send { phone/email }
+    API->>SB: signInWithOtp / service insert
+    SB-->>API: OTP issued (email or SMS)
+    API-->>B: { ok, message }
+
+    B->>API: POST /api/otp/verify { phone, code }
+    API->>SB: Lookup otp + auth.signInWithOtp
+    SB-->>API: user session
+    API-->>B: { ok, user }
+    B->>SB: auth.setSession / exchange (client)
+
+    B->>API: POST /api/auth/sync { access, refresh }
+    API->>ST: Set-Cookie sb-access-token / sb-refresh-token
+    API-->>B: { ok: true }
+
+    B->>SB: Profile updates during onboarding
+    SB-->>B: Upsert confirmations
+
+    B->>ST: localStorage.setItem(gn.local.secret)
+
+    B->>API: (optional) logout route
+    API->>ST: Clear cookies
+    B-->>B: Redirect to /join
+```
+
+## Supporting Tables
+
+### Data Contract Table
+| Name | Shape | Set by | Consumed by | Notes |
+| --- | --- | --- | --- | --- |
+| `/api/otp/send` request | `{ phone?: string, email?: string, identifier?: string }` | Join client | OTP send route | Rejects non-`+977` phones; email goes straight to Supabase OTP. |
+| `/api/otp/send` response | `{ ok: boolean, channel?: 'sms'|'email', message: string }` | OTP send route | Join client UI | Sets success/error toast; no redirects. |
+| `/api/otp/verify` request | `{ phone: string, code: string }` | Join phone verify, OTP login helper | OTP verify route | Requires stored OTP in `otps` table. |
+| `/api/otp/verify` response | `{ ok: true, user }` or `{ ok: false, error }` | OTP verify route | Join client, `verifyOtpAndSync` | **Does not** return access tokens — join flow expects them. |
+| `/api/auth/sync` request | `{ access_token: string, refresh_token?: string|null }` | Login flows, TrustStep, browser sync | Auth sync route | Fails if `access_token` missing; sets modern + legacy cookies. |
+| Supabase browser storage | `localStorage['gatishil.auth.token']` | Supabase client | Supabase auth refresh logic | Mirrors session for SPA persistence. |
+| Local PIN | `localStorage['gn.local.secret']`, `['gn.local.salt']` | TrustStep | `hasLocalPin`, `unlockWithPin` | AES-GCM encrypted secret derived from PIN. |
+| Session Storage | `sessionStorage['pending_id']` | (Legacy flows) | `/verify/VerifyClient` | Determines identifier to verify; now set elsewhere. |
+| Cookies | `sb-access-token`, `sb-refresh-token`, `supabase-auth-token`, `webauthn_challenge` | Auth sync route, WebAuthn helpers | Middleware, server Supabase clients, WebAuthn flows | Legacy cookie ensures backward compatibility. |
+
+### Risk Heatmap
+| Risk | Impact | Evidence | Mitigation |
+| --- | --- | --- | --- |
+| Phone OTP verify response lacks tokens | Join phone flow throws “tokens missing”, blocking dashboard redirect. | Join client expects `access_token` from `/api/otp/verify`.【F:app/join/JoinClient.tsx†L170-L192】 vs. API returning only `{ user }`.【F:app/api/otp/verify/route.ts†L65-L72】 | Update API to return tokens or swap client to use `verifyOtpAndSync`. |
+| OTP storage mismatch (`otp_store` vs `otps`) | Phone verification may never find matching code. | Send route inserts into `otp_store`.【F:app/api/otp/send/route.ts†L8-L115】 Verify route queries `otps`.【F:app/api/otp/verify/route.ts†L31-L61】 | Align both routes on same table or add migration/cron sync. |
+| Email OTP path skips cookie sync | User reaches `/onboard` but server pages lack tokens. | Email verify redirects without calling `/api/auth/sync`.【F:app/join/JoinClient.tsx†L224-L239】 | Invoke `verifyOtpAndSync` or manual cookie sync before redirect. |
+| Onboarding open to anonymous users | Unauthenticated visitors can hit `/onboard` and trigger storage errors. | Middleware treats `/onboard` as public.【F:middleware.ts†L13-L22】 | Add guard to redirect to `/join` when no Supabase session. |
+| TrustStep fails without Supabase session | Cookie sync throws “No active session”, stranding users. | TrustStep fetches session before sync.【F:components/onboard/TrustStep.jsx†L8-L56】 | Surface retry, or ensure session establishment earlier. |
+| Local PIN only client-side | No server validation; stolen device bypass possible. | PIN stored solely in localStorage.【F:lib/localPin.ts†L22-L49】 | Consider server challenge or WebAuthn enforcement. |
+| Middleware trusts stale cookies | Stale/expired tokens still allow `/dashboard` fetch attempt. | Middleware checks only cookie presence.【F:middleware.ts†L24-L41】 | Validate token expiry via Supabase before allowing. |
+| Callback without `code`/`token_hash` traps user | Shows error requiring manual navigation. | Auth callback demands query params.【F:app/auth/callback/Client.tsx†L49-L90】 | Provide fallback link to `/join` or auto-redirect after timeout. |
+
+## How to debug safely
+
+When a login attempt fails, start at `/join`: confirm `/api/otp/send` responses and ensure the correct table receives the OTP. Follow the flow through `/api/otp/verify` (checking that tokens return and cookies sync), then step into `/onboard` to verify profile writes, TrustStep PIN storage, and `/api/auth/sync` calls; finish by inspecting middleware + `/dashboard` server logs. This map lets you trace each hop without guessing which module redirects next or which storage layer (Supabase, cookies, local PIN) might be stale.


### PR DESCRIPTION
## Summary
- add AUTH_CONTROL_TOWER.md describing Gatishil Nepal auth journey from /join to /dashboard
- document relevant routes, APIs, libraries, and onboarding components with redirects and side effects
- provide guard matrix, state machine, request swimlane, data contracts, and risk heatmap for debugging

## Testing
- not run (documentation change only)


------
https://chatgpt.com/codex/tasks/task_e_68f4f3ab467c832c9f1664ab2bfadd3b