### PR TITLE
Allow remote avatars for dashboard

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,6 +11,18 @@ const nextConfig = {
   typescript: {
     ignoreBuildErrors: true,
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: '*.supabase.co',
+      },
+      {
+        protocol: 'https',
+        hostname: 'lh3.googleusercontent.com',
+      },
+    ],
+  },
   // Only expose public env at build time (sanity guard)
   env: {
     // do not place secrets here


### PR DESCRIPTION
## Summary
- allow Supabase and Google avatar hosts for Next.js Image optimization to prevent SSR failures on the dashboard

## Testing
- npm run lint *(fails: `next` binary unavailable in CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68f5c8b39340832cae194368faa58876