### PR TITLE
Fix Nepal SMS OTP normalization

### DIFF
--- a/app/api/otp/verify/route.ts
+++ b/app/api/otp/verify/route.ts
@@ -48,7 +48,7 @@ export async function POST(req: Request) {
   if (phoneRaw) {
     const normalized = normalizeNepalMobile(phoneRaw);
     if (!normalized) {
-      return respond({ ok: false, message: 'Phone OTP is Nepal-only. Enter +97798… or use email.' }, 400);
+      return respond({ ok: false, message: 'Phone OTP is Nepal-only. Enter 96/97/98… (or +9779…) or use email.' }, 400);
     }
 
     const { data, error } = await supabaseAdmin

--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -67,7 +67,7 @@ function JoinClientBody() {
     resetAlerts();
     const normalized = normalizeNepalMobile(phoneRaw);
     if (!normalized) {
-      setError('Phone OTP is Nepal-only. Enter +97798… or use email.');
+      setError('Phone OTP is Nepal-only. Enter 96/97/98… (or +9779…) or use email.');
       return;
     }
 

--- a/lib/auth/phone.ts
+++ b/lib/auth/phone.ts
@@ -1,4 +1,4 @@
-export const NEPAL_MOBILE = /^\+9779\d{9}$/;
+export const NEPAL_MOBILE = /^\+9779[678]\d{8}$/;
 
 export function normalizeOtpPhone(value: string) {
   const trimmed = value.trim();
@@ -29,11 +29,11 @@ export function normalizeNepalMobile(input: string): string | null {
     normalized = normalized.slice(3);
   }
 
-  if (normalized.startsWith('0')) {
+  if (normalized) {
     normalized = normalized.replace(/^0+/, '');
   }
 
-  if (normalized.length !== 10 || !normalized.startsWith('98')) {
+  if (!/^9[678]\d{8}$/.test(normalized)) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
- expand Nepal phone normalisation so 96/97/98 and +977 formats map to the correct Supabase value
- reuse the shared Nepal mobile helper inside the SMS OTP API and clarify validation messaging
- align join/verify flows with the broader Nepal-only guidance while keeping email untouched

## Testing
- npm run lint *(fails: `next` CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f70d431768832ca2f8e05b800a3114