### PR TITLE
Fix SMS OTP gateway formatting

### DIFF
--- a/app/api/otp/send/route.ts
+++ b/app/api/otp/send/route.ts
@@ -92,11 +92,12 @@ async function sendAakashSms(
 ) {
   const { apiKey, senderId, baseUrl } = options;
   const message = OTP_MESSAGE.replace("{code}", code);
+  const gatewayPhone = phone.startsWith("+") ? phone.slice(1) : phone;
   const body = new URLSearchParams({
     key: apiKey,
     route: "sms",
     sender: senderId,
-    phone,
+    phone: gatewayPhone,
     text: message,
   });
 


### PR DESCRIPTION
## Summary
- strip the leading plus sign before sending SMS OTP requests to the Aakash gateway so the API receives digits-only numbers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f719de805c832ca589d119192c7786