### PR TITLE
Unify phone and email OTP onboarding flow

### DIFF
--- a/AUTH_CONTROL_TOWER.md
+++ b/AUTH_CONTROL_TOWER.md
@@ -8,7 +8,7 @@ This control tower distills every moving part of Gatishil Nepal’s authenticati
 | File | Purpose | Key exports / functions | Invoked from | Redirect behavior |
 | --- | --- | --- | --- | --- |
 | `app/join/page.tsx` | Server entry that mounts the client-only join experience. | Default page component. | App Router for `/join`. | Defers to client logic for redirects. |
-| `app/join/JoinClient.tsx` | Implements dual email/phone OTP flows, message UI, and redirect-on-session logic. | `JoinClient`, `sendPhoneOtp`, `verifyPhoneOtp`, `sendEmailOtp`, `verifyEmailOtp`. | Rendered by `/join`; calls `/api/otp/*` and Supabase browser client. | Redirects signed-in users to `/onboard?src=join`; phone verify replaces `/onboard?src=join`, email verify replaces `/onboard?src=otp`. |
+| `app/join/JoinClient.tsx` | Implements dual email/phone OTP flows, message UI, and redirect-on-session logic. | `JoinClient`, `sendPhoneOtp`, `verifyPhoneOtp`, `sendEmailOtp`, `verifyEmailOtp`. | Rendered by `/join`; calls `/api/otp/*` and Supabase browser client. | Redirects signed-in users to `/onboard?src=join`; both phone and email verify replace the shared onboarding URL. |
 | `app/verify/page.tsx` | Legacy `/verify` landing now acting as a kill-switch redirect. | Client component. | `/verify`. | Immediately redirects to `/join`. |
 | `app/onboard/page.tsx` | Suspense shell around the onboarding flow. | Default page component with dynamic rendering. | `/onboard`. | None; onboarding flow drives navigation. |
 | `components/OnboardingFlow.tsx` | Orchestrates multi-step onboarding, Supabase code exchange, and final Trust step. | `OnboardingFlow`. | Used by `/onboard`. | Exchanges `code` params for sessions; pushes between steps and finally `/dashboard`. |
@@ -27,7 +27,7 @@ This control tower distills every moving part of Gatishil Nepal’s authenticati
 | File | Purpose | Key exports / functions | Called by | Redirect / Side effects |
 | --- | --- | --- | --- | --- |
 | `app/api/otp/send/route.ts` | Sends OTPs (email via Supabase, phone via Aakash) and logs to `public.otps`. | `POST` handler plus helper send/save functions. | `/join` client (phone/email tabs). | Responds with `{ ok, message }`; enforces 60s cooldown and 5‑minute TTL. |
-| `app/api/otp/verify/route.ts` | Validates phone codes against `public.otps`, tracks attempts, no session issuing. | `POST` handler. | `/join` verify flow; `verifyOtpAndSync`. | Returns `{ ok: true }` only; client finalises Supabase session + cookie sync. |
+| `app/api/otp/verify/route.ts` | Validates phone codes against `public.otps`, tracks attempts, and returns Supabase tokens. | `POST` handler. | `/join` verify flow; `verifyOtpAndSync`. | Returns `{ ok, access_token, refresh_token, next }`; client sets session and syncs cookies. |
 | `app/api/auth/sync/route.ts` | Writes Supabase access/refresh tokens into secure cookies (plus legacy JSON). | `OPTIONS`, `POST`. | Login flows, TrustStep, Supabase browser sync. | No redirect; response `{ ok: true }` with Set-Cookie. |
 
 ### Shared Libraries & Utilities
@@ -37,7 +37,7 @@ This control tower distills every moving part of Gatishil Nepal’s authenticati
 | `lib/supabase/browser.ts` | Creates singleton browser client and mirrors tokens into cookies. | `getSupabaseBrowser`, `supabase`. | Login & onboarding UIs. | Syncs via `/api/auth/sync` on sign-in/refresh. |
 | `lib/supabase/server.ts` | SSR Supabase client respecting modern & legacy cookies. | `getSupabaseServer`. | `/dashboard`. | Reads `sb-*` cookies, falls back to legacy JSON. |
 | `lib/supabaseServer.ts` | Older server helper with writeable cookies. | `getServerSupabase`. | `/login`. | Supports legacy cookie decoding. |
-| `lib/auth/verifyOtpClient.ts` | Browser helper that checks `/api/otp/verify`, then verifies with Supabase and syncs cookies. | `verifyOtpAndSync`. | `/join`, `/login`. | Calls Supabase `verifyOtp`, polls for session, then posts to `/api/auth/sync`. |
+| `lib/auth/verifyOtpClient.ts` | Browser helper that checks `/api/otp/verify`, then seeds the Supabase browser client and syncs cookies. | `verifyOtpAndSync`. | `/join`, `/login`. | Calls `/api/otp/verify`, sets session via `getSupabaseBrowser`, triggers `/api/auth/sync`. |
 | `lib/auth/waitForSession.ts` | Polls Supabase until a session appears. | `waitForSession`. | `verifyOtpAndSync`, `/join` email flow. | Returns tokens for cookie sync. |
 | `lib/auth/next.ts` | Sanitizes `next` redirect values. | `getValidatedNext`. | `/login` client. | Blocks external redirects. |
 | `lib/auth/validate.ts` | Shared identifier helpers (legacy). | `isPhone`, `isEmail`, `maskIdentifier`. | *(deprecated)*. | Left for potential reuse; not referenced in current flow. |
@@ -69,7 +69,7 @@ This control tower distills every moving part of Gatishil Nepal’s authenticati
 | Send phone OTP (`/join`) | Existing session triggers instant move to `/onboard?src=join`. | Normalised to `+97798…` or rejection message. | n/a | n/a | n/a | Persists to `public.otps`, enforces 60 s cooldown and 5 min TTL. |
 | Verify phone OTP (`/join`) | Requires matching record in `public.otps`. | Phone only. | Match → `/onboard?src=join`; mismatch → attempt++ with error toast. | Locks after 5 attempts per OTP. | n/a | `verifyOtpAndSync` calls Supabase `verifyOtp` then `/api/auth/sync`. |
 | Send email OTP (`/join`) | Existing session rerouted before action. | Email only. | n/a | n/a | n/a | API invokes `supabase.auth.signInWithOtp`, UI starts 60 s resend timer. |
-| Verify email OTP (`/join`) | `verifyOtpAndSync` handles Supabase verification + cookie sync. | Email only. | Valid code → replace `/onboard?src=otp`; invalid → error toast. | Supabase handles attempts internally. | n/a | Always posts tokens to `/api/auth/sync`. |
+| Verify email OTP (`/join`) | `verifyOtpAndSync` handles Supabase verification + cookie sync. | Email only. | Valid code → replace `/onboard?src=join`; invalid → error toast. | Supabase handles attempts internally. | n/a | Always posts tokens to `/api/auth/sync`. |
 | Name & face “Continue” | Requires Supabase session to upload; absence throws “No session”. | n/a | n/a | n/a | n/a | Successful save leaves user on `/onboard?step=roots`. |
 | Roots “Continue” | Needs Supabase session for profile update. | Chooses Nepal/Abroad meta. | n/a | n/a | n/a | Remains on `/onboard`, pushes to `step=atmadisha` on save. |
 | Ātma Diśā finish | Session required to persist profile traits. | n/a | n/a | n/a | n/a | Calls `onDone` to enter Trust step; no redirect. |

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -19,8 +19,8 @@ This document maps the end-to-end authentication journey for the Gatishil Nepal 
   - **API dependencies:** Fetches `/api/otp/send` (phone), `/api/otp/verify` (phone), `/api/auth/sync` (after session), Supabase direct email OTP.
   - **Redirect logic:**
     - If a session already exists → `router.replace('/onboard?src=join')`.
-    - Phone OTP success → `router.replace('/dashboard')`.
-    - Email OTP success → `router.replace('/onboard?src=otp')`.
+    - Phone OTP success → `router.replace(next ?? '/onboard?src=join')` (server returns `/onboard?src=join`).
+    - Email OTP success → `router.replace(next ?? '/onboard?src=join')` (shared onboarding path).
   - **State touched:**
     - Uses `localStorage` implicitly via Supabase auth storage key `gatishil.auth.token`.
     - Tracks OTP focus using refs; manages UI state (`tab`, `otpSentTo`, etc.).
@@ -223,15 +223,13 @@ flowchart LR
   B -->|Phone +977| C[Call /api/otp/send]
   C --> D[Receive SMS]
   D --> E[Submit code via /api/otp/verify]
-  E --> F[Supabase auth.verifyOtp (client)]
+  E --> F[Supabase auth.setSession]
   F --> G[Sync tokens via /api/auth/sync]
-  G --> H{Middleware sees cookies?}
-  H -->|Yes| I[/dashboard]
-  H -->|No| J[/login?next=/dashboard]
   B -->|Email| K[Supabase signInWithOtp email]
   K --> L[Enter code in Join]
   L --> M[supabase.auth.verifyOtp]
-  M --> N[waitForSession -> /onboard?src=otp]
+  M --> N[waitForSession -> /onboard?src=join]
+  G --> N
   N --> O[Welcome]
   O --> P[Name & Photo upload]
   P --> Q[Roots location]

--- a/app/api/otp/verify/route.ts
+++ b/app/api/otp/verify/route.ts
@@ -138,7 +138,7 @@ export async function POST(req: Request) {
           refresh_token: s.refresh_token,
           token_type: s.token_type,
           expires_in: s.expires_in,
-          next: "/onboard?src=otp",
+          next: "/onboard?src=join",
         },
         { status: 200 }
       );
@@ -147,15 +147,17 @@ export async function POST(req: Request) {
     // ─────────────────────────────────────────────
     // EMAIL: unchanged — Supabase verifies and returns a session
     // ─────────────────────────────────────────────
-    if (typeof email === "string" && typeof token === "string") {
+    if (typeof email === "string" && (typeof token === "string" || typeof code === "string")) {
       if (!URL || !ANON) {
         return NextResponse.json({ ok: false, error: "SERVER_MISCONFIG" }, { status: 500 });
       }
       const sb = createClient(URL, ANON, { auth: { persistSession: false } });
 
+      const otp = (typeof token === "string" ? token : code)!.trim();
+
       const { data, error } = await sb.auth.verifyOtp({
         email: email.trim(),
-        token: token.trim(),
+        token: otp,
         type: (type as any) ?? "email",
       });
 
@@ -181,7 +183,7 @@ export async function POST(req: Request) {
           refresh_token: session.refresh_token,
           token_type: session.token_type,
           expires_in: session.expires_in,
-          next: "/onboard?src=otp",
+          next: "/onboard?src=join",
         },
         { status: 200 }
       );

--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -99,8 +99,9 @@ function JoinClientBody() {
     resetAlerts();
     setPhoneVerifying(true);
     try {
-      await verifyOtpAndSync({ phone: phoneSentTo, code: phoneCode });
-      router.replace('/onboard?src=join');
+      const result = await verifyOtpAndSync({ phone: phoneSentTo, code: phoneCode });
+      const next = typeof result?.next === 'string' ? result.next : '/onboard?src=join';
+      router.replace(next);
     } catch (err: any) {
       setError(err?.message || 'Invalid or expired code.');
     } finally {
@@ -145,8 +146,9 @@ function JoinClientBody() {
     resetAlerts();
     setEmailVerifying(true);
     try {
-      await verifyOtpAndSync({ email: emailSentTo, code: emailCode });
-      router.replace('/onboard?src=otp');
+      const result = await verifyOtpAndSync({ email: emailSentTo, code: emailCode });
+      const next = typeof result?.next === 'string' ? result.next : '/onboard?src=join';
+      router.replace(next);
     } catch (err: any) {
       setError(err?.message || 'Invalid or expired code.');
     } finally {

--- a/lib/auth/verifyOtpClient.ts
+++ b/lib/auth/verifyOtpClient.ts
@@ -2,13 +2,25 @@
 // PHONE uses our API (Custom SoT), EMAIL uses Supabase via API.
 // On success (phone), set session with returned tokens.
 
-import { createClient } from "@supabase/supabase-js";
+import { getSupabaseBrowser } from "@/lib/supabaseClient";
 
-export async function verifyOtpAndSync(input: { phone?: string; code?: string; email?: string; token?: string; type?: string }) {
+type VerifyInput = { phone?: string; code?: string; email?: string; token?: string; type?: string };
+
+export async function verifyOtpAndSync(input: VerifyInput) {
+  const payload: Record<string, unknown> = { ...input };
+
+  if (payload.email && payload.code && !payload.token) {
+    payload.token = payload.code;
+    delete payload.code;
+    if (!payload.type) {
+      payload.type = "email";
+    }
+  }
+
   const res = await fetch("/api/otp/verify", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(input),
+    body: JSON.stringify(payload),
   });
   const j = await res.json().catch(() => ({}));
   if (!res.ok || !j?.ok) {
@@ -16,12 +28,12 @@ export async function verifyOtpAndSync(input: { phone?: string; code?: string; e
     throw new Error(msg);
   }
 
-  // For phone verification, API returns tokens. For email, your existing flow may set session elsewhere.
-  if (input.phone && j.access_token && j.refresh_token) {
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-    const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string;
-    const supabase = createClient(url, anon);
-    await supabase.auth.setSession({ access_token: j.access_token, refresh_token: j.refresh_token });
+  if (j.access_token) {
+    const supabase = getSupabaseBrowser();
+    await supabase.auth.setSession({
+      access_token: j.access_token,
+      refresh_token: j.refresh_token ?? null,
+    });
   }
 
   return j;


### PR DESCRIPTION
## Summary
- normalize the OTP verification helper to feed email codes into Supabase, seed the browser client session, and reuse API-provided redirects
- update `/join` verification handlers so both phone and email OTP flows land on the shared onboarding wizard
- adjust the OTP verify API and documentation to return the common onboarding URL and accept email code aliases

## Testing
- npm run lint *(fails: `next` binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f8600a68e8832c8b1d3c8a64f5034d