### PR TITLE
Refactor join OTP flows into separate phone and email lanes

### DIFF
--- a/app/api/otp/email/send/route.ts
+++ b/app/api/otp/email/send/route.ts
@@ -1,18 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
  * POST /api/otp/email/send
  * Body: { email: string, redirectTo?: string }
- * Thin wrapper around Supabase Email OTP (client-native recommended).
- * Returns 200/400 JSON, never 500 for expected failures.
+ * Legacy facade retained for backwards compatibility.
+ * Email OTP is now handled entirely in the browser via Supabase client SDK.
  */
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const SUPABASE_ANON = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string) || (process.env.SUPABASE_ANON_KEY as string);
-
 const j = (status: number, body: unknown) => NextResponse.json(body, { status });
 
 const isValidEmail = (v: string) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v);
@@ -21,26 +16,11 @@ export async function POST(req: NextRequest) {
   let body: any = {};
   try { body = await req.json(); } catch { return j(400, { ok: false, error: "BAD_JSON" }); }
   const email = (body?.email || "").trim().toLowerCase();
-  const redirectTo = typeof body?.redirectTo === "string" ? body.redirectTo : "";
   if (!email) return j(400, { ok: false, error: "EMAIL_REQUIRED" });
   if (!isValidEmail(email)) return j(400, { ok: false, error: "INVALID_EMAIL" });
-
-  const origin = req.headers.get("origin") || "https://www.gatishilnepal.org";
-  const emailRedirectTo = redirectTo && redirectTo.startsWith("http") ? redirectTo : `${origin}/onboard?src=join`;
-
-  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON, { auth: { persistSession: false } });
-  const { error } = await supabase.auth.signInWithOtp({
-    email,
-    options: { shouldCreateUser: true, emailRedirectTo }
+  return j(410, {
+    ok: false,
+    error: "EMAIL_ROUTE_CLIENT_ONLY",
+    message: "Email OTP must be requested via the Supabase browser client.",
   });
-
-  if (error) {
-    return j(400, {
-      ok: false,
-      error: "SUPABASE_EMAIL_OTP_ERROR",
-      message: error.message,
-      debug: { emailRedirectTo }
-    });
-  }
-  return j(200, { ok: true, message: "Email OTP sent." });
 }

--- a/app/api/otp/email/verify/route.ts
+++ b/app/api/otp/email/verify/route.ts
@@ -1,17 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 /**
  * POST /api/otp/email/verify
  * Body: { email: string, token: string }
- * Thin wrapper for Supabase verifyOtp (client-native recommended).
+ * Legacy facade retained for backwards compatibility.
+ * Email OTP verification must be performed in the browser via Supabase client SDK.
  */
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL as string;
-const SUPABASE_ANON = (process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY as string) || (process.env.SUPABASE_ANON_KEY as string);
-
 const j = (status: number, body: unknown) => NextResponse.json(body, { status });
 
 export async function POST(req: NextRequest) {
@@ -20,10 +16,9 @@ export async function POST(req: NextRequest) {
   const email = (body?.email || "").trim().toLowerCase();
   const token = (body?.token || "").trim();
   if (!email || !token) return j(400, { ok: false, error: "EMAIL_AND_TOKEN_REQUIRED" });
-
-  const supabase = createClient(SUPABASE_URL, SUPABASE_ANON, { auth: { persistSession: false } });
-  const { error } = await supabase.auth.verifyOtp({ email, token, type: "email" });
-
-  if (error) return j(400, { ok: false, error: "SUPABASE_EMAIL_VERIFY_ERROR", message: error.message });
-  return j(200, { ok: true, message: "Email verified." });
+  return j(410, {
+    ok: false,
+    error: "EMAIL_ROUTE_CLIENT_ONLY",
+    message: "Email OTP must be verified via the Supabase browser client.",
+  });
 }

--- a/app/api/otp/phone/send/route.ts
+++ b/app/api/otp/phone/send/route.ts
@@ -11,7 +11,7 @@ const AAKASH_SMS_API_KEY = process.env.AAKASH_SMS_API_KEY as string;
 
 const admin = () => createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
 
-const NEPAL_E164 = /^\+977\d{9,10}$/;
+const NEPAL_E164 = /^\+9779[78]\d{8}$/;
 const ttlMinutes = 5;
 const resendSeconds = 30;
 

--- a/app/api/otp/phone/verify/route.ts
+++ b/app/api/otp/phone/verify/route.ts
@@ -14,7 +14,7 @@ const anon = () => createClient(SUPABASE_URL, SUPABASE_ANON, { auth: { persistSe
 const admin = () => createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, { auth: { persistSession: false } });
 
 const j = (status: number, body: unknown) => NextResponse.json(body, { status });
-const NEPAL_E164 = /^\+977\d{9,10}$/;
+const NEPAL_E164 = /^\+9779[78]\d{8}$/;
 const sha256Hex = (s: string) => crypto.createHash("sha256").update(s).digest("hex");
 
 function toLocal(msisdn: string): string | null {


### PR DESCRIPTION
## Summary
- rework the join page so phone OTPs hit the dedicated `/api/otp/phone/*` endpoints while email OTPs use the Supabase browser client, keeping timers and redirects aligned with server policy
- tighten the phone OTP API validation to +977 97/98 numbers, keep the 30s throttle, and return session payloads consumed by the client
- convert legacy email OTP API handlers into 410 facades and refresh docs/utilities to describe the split architecture

## Testing
- npm run lint *(fails: `next` binary not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8bac102f0832cb1c999d59c10cdc9