### PR TITLE
Refactor profile operations to use id-based upserts

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -48,7 +48,7 @@ export default async function DashboardPage() {
 
   // Best-effort profile/link loads. We log problems but never throw (no white screen).
   const { data: profile, error: profileErr } =
-    await supabase.from('profiles').select('*').eq('user_id', user.id).maybeSingle();
+    await supabase.from('profiles').select('*').eq('id', user.id).maybeSingle();
   if (profileErr) console.error('dashboard:profiles error', profileErr);
 
   const profilePhone = typeof (profile as any)?.phone === 'string' ? String((profile as any).phone) : null;
@@ -65,7 +65,7 @@ export default async function DashboardPage() {
   if (linkErr) console.error('dashboard:user_person_links error', linkErr);
 
   const enriched = {
-    user_id: user.id,
+    id: user.id,
     phone: user.phone ?? profilePhone ?? null,
     email: user.email ?? null,
     name: profile?.name ?? null,

--- a/app/security/SecurityClient.tsx
+++ b/app/security/SecurityClient.tsx
@@ -28,7 +28,7 @@ export default function SecurityClient() {
           const { data: profile } = await supabase
             .from('profiles')
             .select('phone,email')
-            .eq('user_id', sess.user.id)
+            .eq('id', sess.user.id)
             .maybeSingle();
           profilePhone = typeof profile?.phone === 'string' ? profile.phone : null;
           profileEmail = typeof profile?.email === 'string' ? profile.email : null;
@@ -51,7 +51,7 @@ export default function SecurityClient() {
       const role = params.get('role');
       if (sess && (name || role)) {
         // Example if you have public.profiles:
-        // await supabase.from('profiles').upsert({ user_id: sess.user.id, name, role });
+        // await supabase.from('profiles').upsert({ id: sess.user.id, name, role }, { onConflict: 'id' });
       }
     })();
   }, [params]);


### PR DESCRIPTION
## Summary
- replace profile bootstrap insert with an id-based upsert that always includes the authenticated user id
- load dashboard and security profile data by filtering on the profile id instead of the old user_id column
- refresh inline documentation to reference the new id-based profiles upsert pattern

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f9c20ef59c832ca7288806ec3e9442