### PR TITLE
Add middleware guard for protected routes

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -1,11 +1,53 @@
-// Inert middleware: disabled to stop redirect loops
 import { NextResponse, type NextRequest } from 'next/server'
 
-export function middleware(_req: NextRequest) {
-  return NextResponse.next()
+const PROTECTED_PREFIXES = ['/dashboard', '/onboard', '/people'] as const
+
+const PROTECTED_MATCHERS = Array.from(
+  new Set(
+    PROTECTED_PREFIXES.map((prefix) => {
+      const normalized = prefix.endsWith('/') ? prefix.slice(0, -1) : prefix
+      return `${normalized}/:path*`
+    }),
+  ),
+)
+
+function hasSupabaseSession(req: NextRequest) {
+  const accessToken = req.cookies.get('sb-access-token')?.value
+  if (accessToken && accessToken !== 'null' && accessToken !== 'undefined') return true
+
+  const legacy = req.cookies.get('supabase-auth-token')?.value
+  if (legacy) {
+    try {
+      const parsed = JSON.parse(legacy)
+      if (parsed && typeof parsed === 'object' && parsed.access_token) return true
+    } catch {
+      // ignore malformed legacy cookie values
+    }
+  }
+
+  return false
 }
 
-// Match nothing real so this never runs
+export function middleware(req: NextRequest) {
+  const url = req.nextUrl
+  const path = url.pathname
+
+  const protectedPath = PROTECTED_PREFIXES.some((prefix) => path.startsWith(prefix))
+  if (!protectedPath) return NextResponse.next()
+
+  // Allow onboarding links that arrive with a Supabase `code` to exchange for a session first
+  if (path.startsWith('/onboard') && url.searchParams.has('code')) {
+    return NextResponse.next()
+  }
+
+  if (hasSupabaseSession(req)) return NextResponse.next()
+
+  const loginUrl = new URL('/login', url)
+  const nextPath = url.search ? `${path}${url.search}` : path
+  loginUrl.searchParams.set('next', nextPath)
+  return NextResponse.redirect(loginUrl)
+}
+
 export const config = {
-  matcher: ['/__noop__/:path*'],
+  matcher: PROTECTED_MATCHERS,
 }


### PR DESCRIPTION
## Summary
- replace the inert middleware with logic that redirects unauthenticated visitors on protected paths to `/login` with the original destination captured in `next`
- accept Supabase onboarding links carrying a `code` parameter so the session can be established before enforcing the redirect
- derive matcher configuration from the protected path list so the middleware only runs where it is needed

## Testing
- npm install *(fails: registry returned 403 for @node-rs/argon2)*

------
https://chatgpt.com/codex/tasks/task_e_68f9c7f4f138832cb25e147d37d65dc7