### PR TITLE
Return server-committed OTP verification responses

### DIFF
--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -117,14 +117,8 @@ function JoinClientBody() {
         throw new Error(payload?.detail || payload?.error || 'Invalid or expired code.');
       }
 
-      const session = payload?.session;
-      if (session?.access_token && session?.refresh_token) {
-        await supabase.auth.setSession({
-          access_token: session.access_token,
-          refresh_token: session.refresh_token,
-        });
-      } else {
-        await supabase.auth.getSession();
+      if (!payload?.serverCommitted) {
+        throw new Error('Could not complete sign-in. Please try again.');
       }
 
       router.replace('/onboard?src=join');
@@ -220,14 +214,8 @@ function JoinClientBody() {
         throw new Error(msg);
       }
 
-      const session = payload?.session;
-      if (session?.access_token && session?.refresh_token) {
-        await supabase.auth.setSession({
-          access_token: session.access_token,
-          refresh_token: session.refresh_token,
-        });
-      } else {
-        await supabase.auth.getSession();
+      if (!payload?.serverCommitted) {
+        throw new Error('Could not complete sign-in. Please try again.');
       }
 
       router.replace('/onboard?src=join');


### PR DESCRIPTION
## Summary
- update OTP verify handlers to require a session result and return a serverCommitted flag after persisting cookies
- make the join client rely on the server-issued cookies and navigate directly to onboarding

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fb62af0c38832cac526df8235020b0