### PR TITLE
Implement server PIN login flow

### DIFF
--- a/app/api/pin/login/route.ts
+++ b/app/api/pin/login/route.ts
@@ -1,44 +1,39 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
 import { createServerClient } from '@supabase/ssr';
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
-import crypto from 'crypto';
+import { derivePasswordFromPinSync } from '@/lib/crypto/pin';
 
-/** Feature flag for Trust PIN gate */
 const ENABLED = process.env.NEXT_PUBLIC_ENABLE_TRUST_PIN === 'true';
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const PIN_PEPPER = process.env.PIN_PEPPER;
 
-/** Env needed */
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-const PIN_PEPPER = process.env.PIN_PEPPER!;
-
-/** Helpers */
-const b64url = (buf: Buffer) =>
-  buf.toString('base64').replace(/=/g, '').replace(/\+/g, '-').replace(/\//g, '_');
-
-const e164 = (raw: string) => {
-  const s = raw.trim();
-  if (s.startsWith('+')) return s;
-  const digits = s.replace(/\D/g, '');
-  // Nepal-only policy: +977 + 10 digits (mobile usually starts 97/98/96)
+const normalizePhone = (raw: string) => {
+  const trimmed = raw.trim();
+  if (!trimmed) return '';
+  if (trimmed.startsWith('+')) return trimmed;
+  const digits = trimmed.replace(/\D/g, '');
   if (digits.startsWith('977')) return `+${digits}`;
   return `+977${digits}`;
 };
 
-const derivePinPassword = (pin: string, userId: string, saltB64url: string, pepper: string) => {
-  // salt is stored in base64url; convert back to std base64 then to Buffer
-  const saltStd = saltB64url.replace(/-/g, '+').replace(/_/g, '/');
-  const salt = Buffer.from(saltStd, 'base64');
-  const material = Buffer.from(`${pin}:${userId}:${pepper}`, 'utf8');
-  // Parameters must match /api/pin/set exactly
-  const dk = crypto.scryptSync(material, salt, 32, { N: 8192, r: 8, p: 1 }) as Buffer;
-  return b64url(dk);
-};
+const getSupabaseSSR = (req: NextRequest, res: NextResponse) =>
+  createServerClient(SUPABASE_URL!, SUPABASE_ANON!, {
+    cookies: {
+      get: (name: string) => req.cookies.get(name)?.value,
+      set: (name: string, value: string, options: any) => {
+        res.cookies.set({ name, value, ...options });
+      },
+      remove: (name: string, options: any) => {
+        res.cookies.set({ name, value: '', ...options });
+      },
+    },
+  });
 
-/** CORS / method guards */
 export function OPTIONS() {
   return new NextResponse(null, { status: 204 });
 }
+
 export function GET() {
   return new NextResponse('Use POST', { status: 405 });
 }
@@ -50,86 +45,104 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Server misconfigured' }, { status: 500 });
     }
 
-    const { email: rawEmail, phone: rawPhone, pin } = (await req.json().catch(() => ({}))) as {
+    const body = (await req.json().catch(() => ({}))) as {
       email?: string;
       phone?: string;
       pin?: string;
     };
 
-    // Validate inputs: exactly one of email | phone, and a PIN
-    const email = (rawEmail ?? '').trim() || undefined;
-    const phone = rawPhone ? e164(rawPhone) : undefined;
-    if (!pin || (!email && !phone) || (email && phone)) {
-      return NextResponse.json(
-        { error: 'Provide exactly one of {email|phone} and a pin' },
-        { status: 400 }
-      );
+    const emailInput = body.email?.trim() || '';
+    const phoneInput = body.phone?.trim() || '';
+    const pin = String(body.pin ?? '').trim();
+
+    if (!pin || !/^\d{4,8}$/.test(pin)) {
+      return NextResponse.json({ error: 'Invalid PIN' }, { status: 400 });
     }
 
-    // Bind SSR client to response cookies
-    const cookieStore = cookies();
-    const supabaseSSR = createServerClient(SUPABASE_URL, SUPABASE_ANON, {
-      cookies: {
-        getAll: () => cookieStore.getAll(),
-        setAll: (setCookies) => {
-          for (const { name, value, options } of setCookies) cookieStore.set(name, value, options);
-        },
-      },
-    });
+    const hasEmail = !!emailInput;
+    const hasPhone = !!phoneInput;
+    if (!hasEmail && !hasPhone) {
+      return NextResponse.json({ error: 'Missing email or phone' }, { status: 400 });
+    }
+    if (hasEmail && hasPhone) {
+      return NextResponse.json({ error: 'Provide either email or phone, not both' }, { status: 400 });
+    }
 
-    // 1) Resolve user via public.profiles (id == auth.users.id)
-    const whereCol = email ? 'email' : 'phone';
-    const whereVal = (email ?? phone)!;
-    const { data: profile, error: profErr } = await supabaseSSR
+    const identifierColumn = hasEmail ? 'email' : 'phone';
+    const identifierValue = hasEmail ? emailInput : normalizePhone(phoneInput);
+
+    if (!identifierValue) {
+      return NextResponse.json({ error: 'Invalid identifier' }, { status: 400 });
+    }
+
+    const admin = getSupabaseAdmin();
+
+    const { data: profile, error: profileErr } = await admin
       .from('profiles')
       .select('id, email, phone')
-      .eq(whereCol, whereVal)
+      .eq(identifierColumn, identifierValue)
       .maybeSingle();
 
-    if (profErr) return NextResponse.json({ error: 'DB error resolving user' }, { status: 500 });
-    if (!profile?.id) return NextResponse.json({ error: 'User not found' }, { status: 404 });
+    if (profileErr) {
+      return NextResponse.json({ error: 'Failed to lookup account' }, { status: 500 });
+    }
+    if (!profile?.id) {
+      return NextResponse.json({ error: 'Account not found' }, { status: 404 });
+    }
 
-    const userId: string = profile.id;
+    const userId = profile.id as string;
 
-    // 2) Load PIN salt (must exist and be non-null)
-    const { data: pinRow, error: pinErr } = await supabaseSSR
+    const { data: pinRow, error: pinErr } = await admin
       .from('auth_local_pin')
-      .select('salt')
+      .select('salt, salt_b64')
       .eq('user_id', userId)
       .maybeSingle();
 
-    if (pinErr) return NextResponse.json({ error: 'DB error reading PIN' }, { status: 500 });
-    if (!pinRow?.salt) {
-      // Legacy/buggy records from earlier null-salt write show up here
+    if (pinErr) {
+      return NextResponse.json({ error: 'Failed to read PIN' }, { status: 500 });
+    }
+
+    let saltValue = (pinRow?.salt_b64 || pinRow?.salt || '') as string;
+    if (!saltValue) {
       return NextResponse.json({ error: 'No PIN set for this account' }, { status: 409 });
     }
 
-    // 3) Derive the password exactly like we did in /api/pin/set
-    const derivedPassword = derivePinPassword(pin, userId, pinRow.salt, PIN_PEPPER);
-
-    // 4) Always sign in with the auth user’s PRIMARY EMAIL
-    //    (phone users often have a synthetic email in GoTrue; admin fetch is source of truth)
-    const admin = getSupabaseAdmin();
-    const { data: user, error: userErr } = await admin.auth.admin.getUserById(userId);
-    if (userErr || !user?.user?.email) {
-      // Fallback to profile.email only if admin email is missing
-      if (!profile.email) return NextResponse.json({ error: 'Account email missing' }, { status: 500 });
+    if (saltValue.startsWith('\\x')) {
+      saltValue = Buffer.from(saltValue.slice(2), 'hex').toString('base64');
     }
-    const authEmail = (user?.user?.email ?? profile.email) as string;
 
-    // 5) Server-side sign in (this writes secure HTTP-only cookies to the response)
+    const saltB64 = saltValue.replace(/-/g, '+').replace(/_/g, '/');
+
+    const { derivedB64u: derivedPassword } = derivePasswordFromPinSync({
+      pin,
+      userId,
+      saltB64,
+      pepper: PIN_PEPPER,
+    });
+
+    const { data: authUser, error: authErr } = await admin.auth.admin.getUserById(userId);
+    if (authErr) {
+      return NextResponse.json({ error: 'Failed to load account identity' }, { status: 500 });
+    }
+
+    const authEmail = authUser.user?.email ?? profile.email;
+    if (!authEmail) {
+      return NextResponse.json({ error: 'Account email missing' }, { status: 500 });
+    }
+
+    const res = new NextResponse(null, { status: 204 });
+    const supabaseSSR = getSupabaseSSR(req, res);
+
     const { error: signInErr } = await supabaseSSR.auth.signInWithPassword({
       email: authEmail,
       password: derivedPassword,
     });
 
     if (signInErr) {
-      // If this hits, it almost always means /api/pin/set never synced the derived password into GoTrue
-      return NextResponse.json({ error: 'Invalid PIN for this account' }, { status: 401 });
+      return NextResponse.json({ error: 'Invalid PIN' }, { status: 401 });
     }
 
-    // 6) Done: cookies are set. Client should redirect on 204.
-    return new NextResponse(null, { status: 204 });
+    return res;
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Unexpected error' }, { status: 500 });
   }

--- a/lib/crypto/pin.ts
+++ b/lib/crypto/pin.ts
@@ -24,7 +24,7 @@ export async function derivePasswordFromPin(opts: {
   pepper: string;
   length?: number; // bytes
 }): Promise<{ derivedB64u: string }> {
-  const { pin, userId, salt, pepper, length = 48 } = opts;
+  const { pin, userId, salt, pepper, length = 32 } = opts;
   const material = Buffer.from(`${pin}:${userId}:${pepper}`, 'utf8');
   const N = 1 << 13; // 8192 (~8MiB)
   const r = 8;
@@ -43,7 +43,7 @@ export function derivePasswordFromPinSync(opts: {
   pepper: string;
   length?: number;
 }): { derivedB64u: string } {
-  const { pin, userId, saltB64, pepper, length = 48 } = opts;
+  const { pin, userId, saltB64, pepper, length = 32 } = opts;
   const salt = Buffer.from(saltB64, 'base64');
   const material = Buffer.from(`${pin}:${userId}:${pepper}`, 'utf8');
   const out = crypto.scryptSync(material, salt, length, { N: 1 << 13, r: 8, p: 1 }) as Buffer;


### PR DESCRIPTION
## Summary
- add server-side PIN login endpoint that derives the Supabase password from stored PIN metadata and issues cookies
- ensure PIN setup writes the matching derived password and uses the new 32-byte scrypt output
- update PIN login UI to post to the API endpoint, interpret error codes, and redirect on success

## Testing
- `npm run lint` *(fails: next binary missing before dependencies are installed)*
- `npm install` *(fails: npm 403 retrieving @node-rs/argon2 in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fdc4b5b0ac832cb815e990e8d9f9b6