### PR TITLE
Normalize Supabase browser client initialization

### DIFF
--- a/app/auth/callback/Client.tsx
+++ b/app/auth/callback/Client.tsx
@@ -3,7 +3,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { getSupabaseBrowser } from "@/lib/supabaseClient";
+import { getSupabaseBrowser } from "@/lib/supa";
 
 export default function Client() {
   const router = useRouter();

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,4 @@
+import "@/lib/supa";
 // app/layout.tsx
 import type { Metadata } from "next";
 import "./globals.css";

--- a/app/members/MembersClient.tsx
+++ b/app/members/MembersClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 import React, { useEffect, useState } from 'react';
 import type { User } from '@supabase/supabase-js';
-import { getSupabaseBrowserClient } from '@/lib/supabaseClient';
+import { getSupabaseBrowserClient } from '@/lib/supa';
 
 export default function MembersClient() {
   const [sessionUser, setSessionUser] = useState<User | null>(null);

--- a/app/onboard/TrustStep.jsx
+++ b/app/onboard/TrustStep.jsx
@@ -2,18 +2,10 @@
 
 import React, { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { createClient } from '@supabase/supabase-js';
+import { getSupabaseBrowser } from '@/lib/supa';
 
 // Read build-time feature flag
 const ENABLE_TRUST_PIN = process.env.NEXT_PUBLIC_ENABLE_TRUST_PIN === 'true';
-
-// Minimal browser Supabase client (no SSR helpers needed here)
-function getSupabaseBrowser() {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-  if (!url || !anon) throw new Error('Supabase env not configured');
-  return createClient(url, anon);
-}
 
 /** Wait for a Supabase session to exist (immediately or within a short timeout). */
 async function waitForSession(ms = 15000) {

--- a/app/status/StatusClient.tsx
+++ b/app/status/StatusClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 import React, { useEffect, useState } from 'react';
-import { getSupabaseBrowserClient } from '@/lib/supabaseClient';
+import { getSupabaseBrowserClient } from '@/lib/supa';
 
 export default function StatusClient() {
   const [ready, setReady] = useState(false);

--- a/components/ChautariLocationPicker.jsx
+++ b/components/ChautariLocationPicker.jsx
@@ -1,6 +1,6 @@
 "use client";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { getSupabaseBrowser } from "@/lib/supabaseClient";
+import { getSupabaseBrowser } from "@/lib/supa";
 
 /**
  * ChautariLocationPicker.jsx — Auto-Approve Edition

--- a/components/Nav.tsx
+++ b/components/Nav.tsx
@@ -4,7 +4,7 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import styles from './Nav.module.css';
-import { getSupabaseBrowser } from '@/lib/supabaseClient';
+import { getSupabaseBrowser } from '@/lib/supa';
 import { useI18n } from '@/lib/i18n';
 
 type SessionState = 'unknown' | 'signedOut' | 'signedIn';

--- a/components/onboard/TrustStep.jsx
+++ b/components/onboard/TrustStep.jsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { getSupabaseBrowser } from '@/lib/supabaseClient';
+import { getSupabaseBrowser } from '@/lib/supa';
 import { createLocalPin, hasLocalPin } from '@/lib/localPin';
 
 /** Wait for a Supabase session to exist (immediately or within a short timeout). */


### PR DESCRIPTION
## Summary
- ensure the Supabase browser façade initializes via app layout side-effect import
- normalize components to import getSupabaseBrowser helpers from the shared lib
- remove ad-hoc Supabase client constructors in onboarding trust step

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69038df74b28832c95061f14ab254b20