### PR TITLE
Create Digital Chauṭarī realtime Sunlight Ledger

### DIFF
--- a/app/chautari/AmbientLayer.tsx
+++ b/app/chautari/AmbientLayer.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface AmbientLayerProps {
+  children: React.ReactNode;
+}
+
+type DroneSource = { osc: OscillatorNode; gain: GainNode };
+
+export function AmbientLayer({ children }: AmbientLayerProps) {
+  const [enabled, setEnabled] = useState(false);
+  const [tooltip, setTooltip] = useState("Sound blooms when you join the circle.");
+  const contextRef = useRef<AudioContext | null>(null);
+  const nodesRef = useRef<DroneSource[]>([]);
+
+  useEffect(() => {
+    if (!enabled) {
+      nodesRef.current.forEach(({ osc }) => osc.stop());
+      nodesRef.current = [];
+      contextRef.current?.close().catch(() => undefined);
+      contextRef.current = null;
+      setTooltip("Sound blooms when you join the circle.");
+      return;
+    }
+
+    let cancelled = false;
+    const setup = async () => {
+      if (contextRef.current) {
+        await contextRef.current.resume();
+        if (!cancelled) {
+          setTooltip("Cloud-borne bansuri in C major.");
+        }
+        return;
+      }
+
+      const context = new AudioContext();
+      const base = [196, 246.94, 329.63];
+      const created: DroneSource[] = base.map((freq, index) => {
+        const osc = context.createOscillator();
+        const gain = context.createGain();
+        osc.type = index === 0 ? "sine" : index === 1 ? "triangle" : "sawtooth";
+        osc.frequency.value = freq;
+        gain.gain.value = 0.0006 + index * 0.0003;
+        osc.connect(gain).connect(context.destination);
+        osc.start();
+        return { osc, gain };
+      });
+
+      const lfo = context.createOscillator();
+      const lfoGain = context.createGain();
+      lfo.type = "sine";
+      lfo.frequency.value = 0.08;
+      lfoGain.gain.value = 12;
+      lfo.connect(lfoGain);
+      created[1].osc.frequency.setValueAtTime(base[1], context.currentTime);
+      lfoGain.connect(created[1].osc.frequency);
+      lfo.start();
+
+      nodesRef.current = [...created, { osc: lfo, gain: lfoGain }];
+      contextRef.current = context;
+      if (!cancelled) {
+        setTooltip("Cloud-borne bansuri in C major.");
+      }
+    };
+
+    void setup();
+
+    return () => {
+      cancelled = true;
+      nodesRef.current.forEach(({ osc }) => osc.stop());
+      nodesRef.current = [];
+      contextRef.current?.close().catch(() => undefined);
+      contextRef.current = null;
+    };
+  }, [enabled]);
+
+  return (
+    <div className="chautari-shell">
+      {children}
+      <AnimatePresence>
+        <motion.button
+          key={enabled ? "playing" : "muted"}
+          type="button"
+          onClick={() => setEnabled((value) => !value)}
+          initial={{ opacity: 0, y: 10 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 6 }}
+          transition={{ duration: 0.25 }}
+          className="chautari-ambient-toggle"
+        >
+          <span className="flex items-center gap-3 text-[0.68rem] tracking-[0.32em]">
+            {enabled ? "⏸" : "▶"} {enabled ? "Pause Dawn Drone" : "Hear the Dawn"}
+          </span>
+        </motion.button>
+      </AnimatePresence>
+      <p className="pointer-events-none fixed right-6 bottom-20 text-[0.6rem] uppercase tracking-[0.3em] text-slate-300/70">
+        {tooltip}
+      </p>
+    </div>
+  );
+}

--- a/app/chautari/actions/ActionButton.tsx
+++ b/app/chautari/actions/ActionButton.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { motion } from "framer-motion";
+import type { ActionDefinition } from "@/lib/sunlight";
+
+interface ActionButtonProps {
+  action: ActionDefinition;
+  active?: boolean;
+  onSelect: (action: ActionDefinition) => void;
+}
+
+export function ActionButton({ action, active, onSelect }: ActionButtonProps) {
+  return (
+    <motion.button
+      whileHover={{ scale: 1.02 }}
+      whileTap={{ scale: 0.97 }}
+      onClick={() => onSelect(action)}
+      className={`group relative overflow-hidden rounded-3xl border px-5 py-6 text-left transition focus:outline-none focus:ring-2 focus:ring-amber-200/60 focus:ring-offset-2 focus:ring-offset-slate-950 ${
+        active
+          ? "border-amber-200/60 shadow-[0_0_40px_rgba(250,204,107,0.25)]"
+          : "border-white/10 shadow-[0_8px_40px_rgba(15,23,42,0.45)]"
+      }`}
+      style={{
+        background: `linear-gradient(135deg, ${action.gradient[0]}20, ${action.gradient[1]}40)` as string,
+      }}
+    >
+      <span className="text-3xl drop-shadow-[0_0_8px_rgba(15,23,42,0.75)]">{action.icon}</span>
+      <div className="mt-4 space-y-1">
+        <p className="text-sm font-semibold tracking-wide text-white">
+          {action.label}
+        </p>
+        <p className="text-xs uppercase tracking-[0.28em] text-slate-200/80">{action.mantra}</p>
+      </div>
+      <motion.span
+        aria-hidden
+        className="pointer-events-none absolute inset-0 opacity-0 transition group-hover:opacity-60"
+        style={{
+          background: `radial-gradient(circle at center, ${action.glow}, transparent 65%)`,
+        }}
+      />
+    </motion.button>
+  );
+}

--- a/app/chautari/actions/ActionFeed.tsx
+++ b/app/chautari/actions/ActionFeed.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import {
+  ACTION_DEFINITIONS,
+  formatLedgerTimestamp,
+  type SunlightAction,
+} from "@/lib/sunlight";
+
+interface ActionFeedProps {
+  entries: SunlightAction[];
+}
+
+export function ActionFeed({ entries }: ActionFeedProps) {
+  return (
+    <div className="chautari-feed" role="log" aria-live="polite">
+      <AnimatePresence initial={false}>
+        {entries.map((entry) => {
+          const meta = ACTION_DEFINITIONS[entry.action_type];
+          return (
+            <motion.article
+              layout
+              key={entry.id}
+              initial={{ opacity: 0, y: 12 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -12 }}
+              transition={{ type: "spring", stiffness: 140, damping: 20 }}
+              className="chautari-feed-item"
+            >
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-black/40 text-2xl">
+                {meta.icon}
+              </div>
+              <div className="space-y-1 text-sm">
+                <p className="font-semibold text-white">
+                  {meta.label}
+                  <span className="ml-2 text-xs uppercase tracking-[0.32em] text-amber-200/70">
+                    {entry.user_id.slice(0, 6)}···{entry.user_id.slice(-4)}
+                  </span>
+                </p>
+                {entry.description ? (
+                  <p className="text-xs text-slate-200/80">{entry.description}</p>
+                ) : (
+                  <p className="text-xs italic text-slate-300/70">Voice-only entry</p>
+                )}
+                {entry.voice_url && (
+                  <a
+                    href={entry.voice_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-xs text-amber-200 transition hover:text-amber-100"
+                  >
+                    Listen to whisper →
+                  </a>
+                )}
+              </div>
+              <time className="text-right text-[11px] uppercase tracking-[0.28em] text-slate-300/70">
+                {formatLedgerTimestamp(entry.created_at)}
+              </time>
+            </motion.article>
+          );
+        })}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/app/chautari/actions/ActionModal.tsx
+++ b/app/chautari/actions/ActionModal.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import { logSunlightAction, type ActionDefinition, type SunlightAction } from "@/lib/sunlight";
+
+interface ActionModalProps {
+  open: boolean;
+  action: ActionDefinition | null;
+  onClose: () => void;
+  onLogged?: (action: SunlightAction) => void;
+}
+
+export function ActionModal({ open, action, onClose, onLogged }: ActionModalProps) {
+  const [note, setNote] = useState("");
+  const [voiceUrl, setVoiceUrl] = useState("");
+  const [ward, setWard] = useState("");
+  const [tole, setTole] = useState("");
+  const [status, setStatus] = useState<"idle" | "saving" | "error">("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const noteRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const parseOptionalNumber = (value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) return null;
+    const parsed = Number(trimmed);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+
+  useEffect(() => {
+    if (open) {
+      setStatus("idle");
+      setErrorMessage(null);
+      const timeout = setTimeout(() => noteRef.current?.focus({ preventScroll: true }), 220);
+      return () => clearTimeout(timeout);
+    }
+    setNote("");
+    setVoiceUrl("");
+    setWard("");
+    setTole("");
+    return undefined;
+  }, [open]);
+
+  if (!action) {
+    return null;
+  }
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!note.trim() && !voiceUrl.trim()) {
+      setErrorMessage("Offer at least a few words or a voice link.");
+      return;
+    }
+
+    setStatus("saving");
+    setErrorMessage(null);
+    try {
+      const recorded = await logSunlightAction({
+        action_type: action.type,
+        description: note,
+        voice_url: voiceUrl || undefined,
+        ward_id: parseOptionalNumber(ward),
+        tole_id: parseOptionalNumber(tole),
+      });
+      onLogged?.(recorded);
+      setStatus("idle");
+      onClose();
+    } catch (error) {
+      console.error(error);
+      setStatus("error");
+      setErrorMessage(
+        error instanceof Error ? error.message : "The ledger could not receive this light just yet."
+      );
+    }
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          className="chautari-modal-backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+        >
+          <motion.div
+            className="chautari-modal"
+            initial={{ scale: 0.92, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.96, opacity: 0 }}
+            transition={{ type: "spring", stiffness: 120, damping: 18 }}
+          >
+            <header className="space-y-2">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">Sacred action</p>
+              <h2>{action.icon} {action.label}</h2>
+              <p className="text-sm text-slate-200/80">{action.description}</p>
+              <p className="text-xs uppercase tracking-[0.28em] text-amber-200/80">{action.mantra}</p>
+            </header>
+            <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+              <label className="block space-y-2 text-sm">
+                <span className="text-xs uppercase tracking-[0.2em] text-slate-300/70">Message to the circle</span>
+                <textarea
+                  ref={noteRef}
+                  placeholder="Describe what you did, promised, or witnessed."
+                  value={note}
+                  onChange={(event) => setNote(event.target.value)}
+                />
+              </label>
+              <label className="block space-y-2 text-sm">
+                <span className="text-xs uppercase tracking-[0.2em] text-slate-300/70">Voice link (optional)</span>
+                <input
+                  type="url"
+                  placeholder="https://voice.guthi/nepal-story.mp3"
+                  value={voiceUrl}
+                  onChange={(event) => setVoiceUrl(event.target.value)}
+                />
+              </label>
+              <div className="grid gap-3 sm:grid-cols-2">
+                <label className="block space-y-2 text-sm">
+                  <span className="text-xs uppercase tracking-[0.2em] text-slate-300/70">Ward</span>
+                  <input
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="11"
+                    value={ward}
+                    onChange={(event) => setWard(event.target.value)}
+                  />
+                </label>
+                <label className="block space-y-2 text-sm">
+                  <span className="text-xs uppercase tracking-[0.2em] text-slate-300/70">Tole</span>
+                  <input
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    placeholder="04"
+                    value={tole}
+                    onChange={(event) => setTole(event.target.value)}
+                  />
+                </label>
+              </div>
+              {errorMessage && (
+                <p className="text-xs font-medium text-rose-300">{errorMessage}</p>
+              )}
+              <div className="flex items-center justify-between">
+                <button
+                  type="button"
+                  onClick={onClose}
+                  className="rounded-full border border-white/15 px-4 py-2 text-xs uppercase tracking-[0.28em] text-slate-300/70 transition hover:border-amber-200/60 hover:text-amber-200"
+                >
+                  Close
+                </button>
+                <button type="submit" disabled={status === "saving"}>
+                  {status === "saving" ? "Sending..." : "Log to sunlight ledger"}
+                </button>
+              </div>
+            </form>
+            <footer className="chautari-modal-footer">
+              <span>Every entry is public, signed, and timestamped.</span>
+              <span>Supabase • Realtime</span>
+            </footer>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/app/chautari/actions/MandalCanvas.tsx
+++ b/app/chautari/actions/MandalCanvas.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import { actionColor } from "@/lib/realtime";
+import type { SunlightAction } from "@/lib/sunlight";
+
+interface MandalCanvasProps {
+  entries: SunlightAction[];
+}
+
+type OrbState = {
+  angle: number;
+  radius: number;
+  drift: number;
+};
+
+const hexToRgba = (hex: string, alpha: number) => {
+  const value = hex.replace("#", "");
+  const r = parseInt(value.slice(0, 2), 16);
+  const g = parseInt(value.slice(2, 4), 16);
+  const b = parseInt(value.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+};
+
+export function MandalCanvas({ entries }: MandalCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const orbitMapRef = useRef<Map<string, OrbState>>(new Map());
+  const orderedEntries = useMemo(() => [...entries].slice(0, 64), [entries]);
+
+  useEffect(() => {
+    const map = orbitMapRef.current;
+    const ids = new Set(orderedEntries.map((entry) => entry.id));
+    // prune old entries
+    for (const key of map.keys()) {
+      if (!ids.has(key)) {
+        map.delete(key);
+      }
+    }
+    orderedEntries.forEach((entry, index) => {
+      if (!map.has(entry.id)) {
+        map.set(entry.id, {
+          angle: Math.random() * Math.PI * 2,
+          radius: 80 + Math.sqrt(index) * 26,
+          drift: 0.25 + Math.random() * 0.65,
+        });
+      }
+    });
+  }, [orderedEntries]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const context = canvas.getContext("2d");
+    if (!context) return;
+
+    let animationFrame = 0;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      const { clientWidth, clientHeight } = canvas;
+      canvas.width = clientWidth * dpr;
+      canvas.height = clientHeight * dpr;
+      if ("resetTransform" in context) {
+        context.resetTransform();
+      } else {
+        context.setTransform(1, 0, 0, 1, 0, 0);
+      }
+      context.scale(dpr, dpr);
+    };
+
+    resize();
+    const resizeObserver = new ResizeObserver(resize);
+    resizeObserver.observe(canvas);
+
+    const render = (time: number) => {
+      const { clientWidth: width, clientHeight: height } = canvas;
+      context.clearRect(0, 0, width, height);
+      context.save();
+      context.globalAlpha = 0.7;
+      const gradient = context.createRadialGradient(
+        width / 2,
+        height / 2,
+        30,
+        width / 2,
+        height / 2,
+        Math.max(width, height) / 1.4,
+      );
+      gradient.addColorStop(0, "rgba(148, 163, 184, 0.08)");
+      gradient.addColorStop(1, "rgba(15, 23, 42, 0.65)");
+      context.fillStyle = gradient;
+      context.fillRect(0, 0, width, height);
+      context.restore();
+
+      orderedEntries.forEach((entry, index) => {
+        const orb = orbitMapRef.current.get(entry.id);
+        if (!orb) return;
+        const baseAngle = orb.angle + (time / 1000) * 0.12 * orb.drift;
+        const wobble = Math.sin(time / 1200 + index) * 8;
+        const radius = orb.radius + wobble;
+        const centerX = width / 2 + Math.cos(baseAngle) * radius;
+        const centerY = height / 2 + Math.sin(baseAngle) * radius * 0.6;
+        const color = actionColor(entry.action_type);
+
+        const glow = context.createRadialGradient(centerX, centerY, 0, centerX, centerY, 68);
+        glow.addColorStop(0, hexToRgba(color, 0.55));
+        glow.addColorStop(1, hexToRgba(color, 0));
+        context.beginPath();
+        context.fillStyle = glow;
+        context.arc(centerX, centerY, 46, 0, Math.PI * 2);
+        context.fill();
+
+        const orbGradient = context.createRadialGradient(centerX, centerY, 6, centerX, centerY, 30);
+        orbGradient.addColorStop(0, hexToRgba("#ffffff", 0.85));
+        orbGradient.addColorStop(1, hexToRgba(color, 0.9));
+        context.beginPath();
+        context.fillStyle = orbGradient;
+        context.arc(centerX, centerY, 22 + Math.sin(time / 800 + index) * 2, 0, Math.PI * 2);
+        context.fill();
+      });
+
+      animationFrame = requestAnimationFrame(render);
+    };
+
+    animationFrame = requestAnimationFrame(render);
+
+    return () => {
+      cancelAnimationFrame(animationFrame);
+      resizeObserver.disconnect();
+    };
+  }, [orderedEntries]);
+
+  return (
+    <div className="chautari-mandal" aria-hidden>
+      <canvas ref={canvasRef} />
+      <div className="pointer-events-none absolute inset-x-0 bottom-6 flex justify-center text-xs uppercase tracking-[0.4em] text-slate-200/60">
+        <span>Realtime Mandal — every orb is a living civic act</span>
+      </div>
+    </div>
+  );
+}

--- a/app/chautari/layout.tsx
+++ b/app/chautari/layout.tsx
@@ -1,0 +1,10 @@
+import "@/styles/chautari.css";
+import { AmbientLayer } from "./AmbientLayer";
+
+export default function ChautariLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <AmbientLayer>{children}</AmbientLayer>;
+}

--- a/app/chautari/page.tsx
+++ b/app/chautari/page.tsx
@@ -1,412 +1,213 @@
-'use client';
+"use client";
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import { AnimatePresence, motion } from 'framer-motion';
+import { useEffect, useMemo, useState } from "react";
+import { motion } from "framer-motion";
+import {
+  ORDERED_ACTIONS,
+  type ActionDefinition,
+  type ActionType,
+  type SunlightAction,
+  fetchRecentActions,
+} from "@/lib/sunlight";
+import { subscribeToActionStream } from "@/lib/realtime";
+import { ActionButton } from "./actions/ActionButton";
+import { ActionFeed } from "./actions/ActionFeed";
+import { ActionModal } from "./actions/ActionModal";
+import { MandalCanvas } from "./actions/MandalCanvas";
 
-const ACTIONS = [
-  {
-    type: 'tree',
-    label: 'रूख रोप्नुहोस् · Plant a Tree',
-    mantra: 'हरियो स्वास, साझा प्रतिज्ञा',
-    color: 'from-emerald-400 via-emerald-500 to-lime-300',
-    icon: '🌱',
-    unit: 'saplings'
-  },
-  {
-    type: 'donation',
-    label: 'एक रुपैया उज्यालो · Give a Rupee',
-    mantra: 'साना हातहरू, ठूलो उज्यालो',
-    color: 'from-amber-400 via-orange-400 to-rose-400',
-    icon: '💧',
-    unit: 'rupees'
-  },
-  {
-    type: 'vote',
-    label: 'मत देऊ · Cast a Pulse Vote',
-    mantra: 'साझा हृदय, साझा दिशा',
-    color: 'from-sky-400 via-cyan-400 to-indigo-400',
-    icon: '🔆',
-    unit: 'votes'
-  },
-  {
-    type: 'voice',
-    label: 'आवाज छोड्नुहोस् · Leave a Voice',
-    mantra: 'बोल्दा देखिन्छ, सुन्दा बन्छ',
-    color: 'from-rose-400 via-fuchsia-400 to-purple-400',
-    icon: '🔊',
-    unit: 'voices'
-  }
-] as const;
-
-type ActionType = (typeof ACTIONS)[number]['type'];
-
-type Contribution = {
-  id: string;
-  actor: string;
-  action: ActionType;
-  quantity: number;
-  nepali: string;
-  english: string;
-  createdAt: number;
-  intensity: number;
+const INITIAL_COUNTS: Record<ActionType, number> = {
+  seed: 0,
+  water: 0,
+  hive: 0,
+  fire: 0,
+  whisper: 0,
+  grain: 0,
+  reflect: 0,
+  miracle: 0,
 };
 
-const SAMPLE_NAMES = ['Sita', 'Ram', 'Bishnu', 'Tara', 'Asmita', 'Ganesh', 'Mira', 'Kiran'];
-const SAMPLE_LOCALES = ['Kavre', 'Dang', 'Khotang', 'Lalitpur', 'Kailali', 'Okhaldhunga'];
-
-function randomChoice<T>(arr: readonly T[]): T {
-  return arr[Math.floor(Math.random() * arr.length)];
-}
-
-function createContribution(action: ActionType): Contribution {
-  const quantity = action === 'donation' ? Math.floor(Math.random() * 100) + 1 : 1;
-  const actor = `${randomChoice(SAMPLE_NAMES)} (${randomChoice(SAMPLE_LOCALES)})`;
-  const phrases: Record<ActionType, [string, string]> = {
-    tree: ['एक रूख रोपियो', 'A sapling just joined the grove.'],
-    donation: ['एक रुपैया उज्यालोमा थपियो', 'A rupee just fueled the light.'],
-    vote: ['एक मतले दिशा निर्धारण गर्‍यो', 'A pulse vote nudged our shared path.'],
-    voice: ['एक आवाजले सत्य सुनायो', 'A voice breathed truth into the circle.']
-  };
-
-  return {
-    id: crypto.randomUUID(),
-    actor,
-    action,
-    quantity,
-    nepali: phrases[action][0],
-    english: phrases[action][1],
-    createdAt: Date.now(),
-    intensity: 0.35 + Math.random() * 0.55
-  };
-}
-
-function formatTime(timestamp: number) {
-  return new Intl.DateTimeFormat('en-GB', {
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit'
-  }).format(timestamp);
-}
-
-function useAmbientDrone(enabled: boolean) {
-  const contextRef = useRef<AudioContext | null>(null);
-  const sourcesRef = useRef<OscillatorNode[]>([]);
+export default function ChautariPage() {
+  const [entries, setEntries] = useState<SunlightAction[]>([]);
+  const [selectedAction, setSelectedAction] = useState<ActionDefinition>(ORDERED_ACTIONS[0]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    if (!enabled) {
-      sourcesRef.current.forEach((osc) => osc.stop());
-      sourcesRef.current = [];
-      contextRef.current?.close();
-      contextRef.current = null;
-      return;
-    }
+    let active = true;
+    const hydrate = async () => {
+      try {
+        const initial = await fetchRecentActions(40);
+        if (!active) return;
+        setEntries(initial);
+      } catch (error) {
+        console.error(error);
+        if (active) {
+          setStatusMessage("Unable to reach the Sunlight Ledger. Latest actions may appear slowly.");
+        }
+      } finally {
+        if (active) setLoading(false);
+      }
+    };
 
-    const context = new AudioContext();
-    contextRef.current = context;
-
-    const baseFrequencies = [196, 246.94, 329.63];
-    const oscillators = baseFrequencies.map((freq, idx) => {
-      const osc = context.createOscillator();
-      const gain = context.createGain();
-      osc.type = idx === 0 ? 'sine' : 'triangle';
-      osc.frequency.value = freq;
-      gain.gain.value = 0.0008 + idx * 0.0004;
-      osc.connect(gain).connect(context.destination);
-      osc.start();
-      return osc;
+    void hydrate();
+    const channel = subscribeToActionStream({
+      onInsert: (action) => {
+        setEntries((previous) => {
+          const filtered = previous.filter((item) => item.id !== action.id);
+          return [action, ...filtered].slice(0, 80);
+        });
+      },
     });
-
-    sourcesRef.current = oscillators;
 
     return () => {
-      oscillators.forEach((osc) => osc.stop());
-      context.close();
+      active = false;
+      void channel.unsubscribe();
     };
-  }, [enabled]);
-}
-
-function RippleField({ pulses }: { pulses: Contribution[] }) {
-  return (
-    <div className="pointer-events-none absolute inset-0 overflow-hidden">
-      <div className="absolute inset-0 mix-blend-screen opacity-80">
-        {pulses.map((pulse) => (
-          <motion.span
-            key={pulse.id}
-            initial={{ opacity: 0.6, scale: 0.5 }}
-            animate={{ opacity: 0, scale: 4 }}
-            transition={{ duration: 4, ease: 'easeOut' }}
-            className="absolute h-48 w-48 -translate-x-1/2 -translate-y-1/2 rounded-full blur-3xl"
-            style={{
-              top: `${30 + Math.random() * 40}%`,
-              left: `${20 + Math.random() * 60}%`,
-              backgroundImage: `radial-gradient(circle at center, rgba(255,255,255,${pulse.intensity}) 0%, transparent 60%)`
-            }}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-export default function DigitalChautariPage() {
-  const [pulses, setPulses] = useState<Contribution[]>(() =>
-    ACTIONS.map((action) => createContribution(action.type)).slice(0, 3)
-  );
-  const [ambientOn, setAmbientOn] = useState(false);
-  const [selectedAction, setSelectedAction] = useState<ActionType>('tree');
-
-  useAmbientDrone(ambientOn);
-
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setPulses((prev) => {
-        const next = [...prev, createContribution(randomChoice(ACTIONS).type)];
-        return next.slice(-20);
-      });
-    }, 8000);
-
-    return () => clearInterval(interval);
   }, []);
 
-  const aggregate = useMemo(() => {
-    return pulses.reduce<Record<ActionType, number>>((acc, pulse) => {
-      acc[pulse.action] = (acc[pulse.action] ?? 0) + pulse.quantity;
-      return acc;
-    }, { tree: 0, donation: 0, vote: 0, voice: 0 });
-  }, [pulses]);
-
-  const handleAction = () => {
-    setPulses((prev) => {
-      const next = [...prev, createContribution(selectedAction)];
-      return next.slice(-20);
+  const totals = useMemo(() => {
+    const counts = { ...INITIAL_COUNTS };
+    entries.forEach((entry) => {
+      counts[entry.action_type] = (counts[entry.action_type] ?? 0) + 1;
     });
-    if (!ambientOn) {
-      setAmbientOn(true);
-    }
+    return counts;
+  }, [entries]);
+
+  const openActionModal = (action: ActionDefinition) => {
+    setSelectedAction(action);
+    setIsModalOpen(true);
+  };
+
+  const handleLogged = (action: SunlightAction) => {
+    setEntries((previous) => {
+      const filtered = previous.filter((item) => item.id !== action.id);
+      return [action, ...filtered].slice(0, 80);
+    });
   };
 
   return (
-    <main className="relative min-h-screen overflow-hidden bg-gradient-to-b from-slate-950 via-slate-900 to-black text-white">
-      <div className="absolute inset-0 -z-10 opacity-90" aria-hidden>
-        <div className="absolute inset-x-0 top-0 h-1/2 bg-[radial-gradient(circle_at_top,rgba(252,211,77,0.35)_0%,rgba(59,130,246,0.15)_55%,rgba(15,23,42,0.05)_100%)]" />
-        <div className="absolute inset-x-0 bottom-0 h-1/2 bg-[radial-gradient(circle_at_bottom,rgba(56,189,248,0.25)_0%,rgba(236,72,153,0.2)_45%,rgba(15,23,42,0.05)_100%)]" />
-      </div>
-
-      <div className="relative z-10 mx-auto flex w-full max-w-6xl flex-col gap-12 px-4 pb-24 pt-16 sm:px-8">
-        <section className="relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 p-8 shadow-[0_0_100px_rgba(252,211,77,0.2)]">
-          <RippleField pulses={pulses.slice(-5)} />
-          <div className="relative grid gap-10 lg:grid-cols-2">
-            <div className="space-y-6">
-              <div>
-                <p className="text-xs uppercase tracking-[0.3em] text-amber-300/90">डिजिटल चौतारी</p>
-                <h1 className="mt-3 text-3xl font-semibold sm:text-4xl">
-                  Stand beneath the digital Chauṭarī and feel Nepal breathe again.
-                </h1>
-              </div>
-              <p className="text-sm text-slate-200/85 sm:text-base">
-                यो चौतारीमा प्रदर्शन होइन, उपस्थिति मात्र छ। तपाईंले बोलेको प्रत्येक शब्द, रोपेको प्रत्येक रूख, बलेको प्रत्येक दियो सबैले देख्छन् र महसुस गर्छन्। No feeds, no filters—only living proof of each other.
+    <div className="relative mx-auto w-full max-w-6xl px-4 pb-28 pt-16 sm:px-8">
+      <section className="chautari-panel relative overflow-hidden">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,rgba(250,204,107,0.18),transparent_65%)] opacity-70" />
+        <div className="relative grid gap-10 lg:grid-cols-[1.3fr_1fr]">
+          <div className="space-y-6">
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.32em] text-amber-200/80">डिजिटल चौतारी · Digital Chauṭarī</p>
+              <h1 className="text-3xl font-semibold leading-snug text-white sm:text-4xl">
+                Stand beneath the dawn-lit tree where the nation can see, speak, and act together.
+              </h1>
+              <p className="text-sm text-slate-200/85">
+                Presence over performance. Transparency over authority. Emotion before analytics. Every orb is a living act logged on the Sunlight Ledger.
               </p>
-              <p className="text-sm text-slate-200/85 sm:text-base">
-                Every action glows across the mandala ledger. Data is transparent, signed, and held in the open so no hand can hide in the dark. Numbers become ripples of light, fountains of water, bowls of grain, and the beat of a shared heart.
-              </p>
-              <div className="flex flex-wrap gap-3 text-xs text-slate-200/80">
-                <span className="rounded-full border border-white/10 px-3 py-1">Presence over performance</span>
-                <span className="rounded-full border border-white/10 px-3 py-1">Transparency over authority</span>
-                <span className="rounded-full border border-white/10 px-3 py-1">Emotion before analytics</span>
-              </div>
-              <div className="flex items-center gap-4 pt-4">
-                <button
-                  onClick={() => setAmbientOn((prev) => !prev)}
-                  className="flex items-center gap-2 rounded-full border border-white/15 bg-black/40 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-amber-200 transition hover:border-amber-300/60 hover:text-amber-100"
-                >
-                  {ambientOn ? '⏸️ Pause Dawn Drone' : '▶️ Hear the Dawn'}
-                </button>
-                <span className="text-[11px] text-slate-300/80">
-                  {ambientOn ? 'Cloud-borne tanpura humming in C major.' : 'Sound blooms when you join the circle.'}
-                </span>
-              </div>
             </div>
-
-            <div className="relative flex flex-col gap-6 rounded-3xl border border-white/15 bg-black/40 p-6">
-              <span className="text-xs uppercase tracking-[0.3em] text-slate-300/80">Act now</span>
+            <div className="chautari-badge-row">
+              <span className="chautari-badge">Sacred like a temple</span>
+              <span className="chautari-badge">Alive like a festival</span>
+              <span className="chautari-badge">Transparent like sunlight</span>
+            </div>
+            {statusMessage && (
+              <p className="text-xs text-amber-200/80">{statusMessage}</p>
+            )}
+          </div>
+          <div className="flex flex-col justify-between rounded-3xl border border-white/10 bg-black/30 p-6">
+            <div className="space-y-3">
+              <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">Choose your act</p>
               <div className="grid gap-3 sm:grid-cols-2">
-                {ACTIONS.map((action) => (
-                  <button
+                {ORDERED_ACTIONS.map((action) => (
+                  <ActionButton
                     key={action.type}
-                    onClick={() => setSelectedAction(action.type)}
-                    className={`relative overflow-hidden rounded-2xl border ${
-                      selectedAction === action.type
-                        ? 'border-white/40 ring-2 ring-offset-2 ring-offset-black/30 ring-amber-300/40'
-                        : 'border-white/15'
-                    } bg-gradient-to-br ${action.color} px-4 py-5 text-left shadow-lg transition`}
-                  >
-                    <span className="text-2xl">{action.icon}</span>
-                    <p className="mt-3 text-sm font-semibold text-black drop-shadow-[0_0_12px_rgba(255,255,255,0.75)]">
+                    action={action}
+                    active={action.type === selectedAction.type && isModalOpen}
+                    onSelect={openActionModal}
+                  />
+                ))}
+              </div>
+            </div>
+            <motion.button
+              whileTap={{ scale: 0.96 }}
+              type="button"
+              onClick={() => openActionModal(selectedAction)}
+              className="mt-6 inline-flex items-center justify-center gap-3 rounded-full border border-amber-200/60 bg-gradient-to-r from-amber-200/80 via-orange-200/80 to-rose-200/80 px-6 py-3 text-sm font-semibold text-slate-900 shadow-[0_0_35px_rgba(251,191,36,0.35)]"
+            >
+              Send your light into the circle <motion.span animate={{ y: [0, -4, 0] }} transition={{ duration: 1.6, repeat: Infinity }}>
+                ✨
+              </motion.span>
+            </motion.button>
+          </div>
+        </div>
+      </section>
+
+      <section className="mt-12 grid gap-8 lg:grid-cols-[1.55fr_1fr]">
+        <div className="space-y-8">
+          <MandalCanvas entries={entries} />
+          <div className="chautari-panel">
+            <header className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-amber-200">Sunlight Feed · जिउँदो बहि</h2>
+                <p className="text-xs uppercase tracking-[0.3em] text-slate-300/70">Every action public, every timestamp signed</p>
+              </div>
+              <span className="text-[11px] uppercase tracking-[0.3em] text-slate-300/60">Supabase Realtime channel</span>
+            </header>
+            <div className="mt-6 min-h-[180px]">
+              {loading ? (
+                <p className="text-sm text-slate-300/80">Gathering the latest pulses…</p>
+              ) : entries.length === 0 ? (
+                <p className="text-sm text-slate-300/80">Be the first to light the ledger today.</p>
+              ) : (
+                <ActionFeed entries={entries.slice(0, 12)} />
+              )}
+            </div>
+          </div>
+        </div>
+
+        <aside className="space-y-6">
+          <div className="chautari-panel">
+            <h3 className="text-sm font-semibold text-amber-200">Collective Vital Signs</h3>
+            <p className="mt-1 text-xs text-slate-300/75">Counts glow as elements, not charts.</p>
+            <div className="mt-5 space-y-4">
+              {ORDERED_ACTIONS.map((action) => (
+                <div key={action.type} className="space-y-2">
+                  <div className="flex items-center justify-between text-xs uppercase tracking-[0.28em] text-slate-300/70">
+                    <span className="flex items-center gap-2 text-white">
+                      <span className="text-lg">{action.icon}</span>
                       {action.label}
-                    </p>
-                    <p className="mt-1 text-xs font-medium uppercase tracking-wide text-black/70">{action.mantra}</p>
-                  </button>
-                ))}
-              </div>
-              <motion.button
-                onClick={handleAction}
-                whileTap={{ scale: 0.97 }}
-                className="group relative overflow-hidden rounded-full border border-amber-200/60 bg-gradient-to-r from-amber-200 via-orange-200 to-rose-200 px-6 py-3 text-sm font-semibold text-slate-900 shadow-[0_0_35px_rgba(251,191,36,0.35)]"
-              >
-                <span className="relative z-10 flex items-center justify-center gap-2">
-                  <span>Send your light into the circle</span>
-                  <motion.span
-                    animate={{ y: [0, -4, 0] }}
-                    transition={{ duration: 1.6, repeat: Infinity, ease: 'easeInOut' }}
-                    className="text-lg"
-                  >
-                    ✨
-                  </motion.span>
-                </span>
-                <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-0 transition group-hover:opacity-60" />
-              </motion.button>
-              <p className="text-[11px] text-slate-300/70">
-                Contributions sign themselves onto a tamper-proof public ledger (Supabase + open merkle proofs in progress). Every Nepali can verify the flow.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        <section className="grid gap-6 lg:grid-cols-[1.5fr_1fr]">
-          <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-            <div className="flex items-center justify-between">
-              <h2 className="text-lg font-semibold text-amber-200">Living Ledger · जिवन्त बहि</h2>
-              <span className="text-[11px] uppercase tracking-widest text-slate-300/70">Transparent by design</span>
-            </div>
-            <p className="mt-2 text-sm text-slate-200/80">
-              Transactions are not hidden in tables—they bloom as pulses of light. Verify every ripple. Watch the circle keep promises in real time.
-            </p>
-            <div className="mt-6 space-y-3">
-              <AnimatePresence>
-                {[...pulses]
-                  .reverse()
-                  .slice(0, 8)
-                  .map((pulse) => {
-                    const actionMeta = ACTIONS.find((a) => a.type === pulse.action)!;
-                    return (
-                      <motion.div
-                        key={pulse.id}
-                        initial={{ opacity: 0, y: 12 }}
-                        animate={{ opacity: 1, y: 0 }}
-                        exit={{ opacity: 0, y: -12 }}
-                        layout
-                        className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-r from-white/10 via-white/5 to-transparent px-4 py-3"
-                      >
-                        <div className="flex items-center justify-between gap-3">
-                          <div className="flex items-center gap-3">
-                            <span className="text-xl">{actionMeta.icon}</span>
-                            <div>
-                              <p className="text-sm font-semibold text-white">{pulse.nepali}</p>
-                              <p className="text-xs text-slate-200/80">{pulse.english}</p>
-                            </div>
-                          </div>
-                          <div className="text-right text-xs text-amber-200/80">
-                            <p>
-                              {pulse.quantity} {actionMeta.unit}
-                            </p>
-                            <p className="text-[11px] tracking-widest text-slate-200/65">{formatTime(pulse.createdAt)}</p>
-                          </div>
-                        </div>
-                        <div className="mt-3 flex items-center justify-between text-[11px] text-slate-200/60">
-                          <span>{pulse.actor}</span>
-                          <span>Integrity hash · #{pulse.id.slice(0, 8)}</span>
-                        </div>
-                      </motion.div>
-                    );
-                  })}
-              </AnimatePresence>
-            </div>
-          </div>
-
-          <div className="flex flex-col gap-6">
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-6">
-              <h3 className="text-sm font-semibold text-amber-200">Collective Vital Signs</h3>
-              <p className="mt-1 text-xs text-slate-300/80">Totals glow as elements, not charts.</p>
-              <div className="mt-4 space-y-4 text-sm">
-                {ACTIONS.map((action) => (
-                  <div key={action.type} className="rounded-2xl border border-white/10 bg-black/40 p-3">
-                    <div className="flex items-center justify-between text-xs uppercase tracking-widest text-slate-300/70">
-                      <span>{action.label.split('·')[0].trim()}</span>
-                      <span>{aggregate[action.type]}</span>
-                    </div>
-                    <div className="mt-2 h-3 overflow-hidden rounded-full bg-white/10">
-                      <motion.div
-                        animate={{ width: `${Math.min(100, aggregate[action.type] * 12)}%` }}
-                        transition={{ duration: 1.2, ease: 'easeOut' }}
-                        className={`h-full rounded-full bg-gradient-to-r ${action.color}`}
-                      />
-                    </div>
-                    <p className="mt-2 text-[11px] text-slate-300/70">
-                      {action.type === 'tree' && 'The grove thickens; every sapling adds oxygen to the shared dawn.'}
-                      {action.type === 'donation' && 'Rūpees shimmer as droplets in the communal kalash, funding public trust.'}
-                      {action.type === 'vote' && 'Pulse votes drum as collective heartbeat, guiding proposals in real time.'}
-                      {action.type === 'voice' && 'Voices weave oral history, archived as light and echo for generations.'}
-                    </p>
+                    </span>
+                    <span>{totals[action.type]}</span>
                   </div>
-                ))}
-              </div>
-            </div>
-
-            <div className="rounded-3xl border border-white/10 bg-white/5 p-6 text-sm text-slate-200/80">
-              <h3 className="text-sm font-semibold text-amber-200">Roadmap to Sacred Trust</h3>
-              <ul className="mt-3 space-y-2 text-xs leading-relaxed">
-                <li>
-                  <span className="font-semibold text-white">On-chain verification:</span> Supabase realtime anchors ledger entries which are mirrored to a public Merkle tree published hourly to Cloudflare R2.
-                </li>
-                <li>
-                  <span className="font-semibold text-white">Voice as first-class citizen:</span> Community radio partners upload voice petitions that auto-transcribe into Nepali + English captions.
-                </li>
-                <li>
-                  <span className="font-semibold text-white">Festival deployments:</span> Portable edge nodes bring Chauṭarī kiosks to village haat bazaars and diaspora gatherings.
-                </li>
-              </ul>
+                  <div className="chautari-stat-bar">
+                    <span
+                      style={{
+                        background: `linear-gradient(90deg, ${action.gradient[0]}, ${action.gradient[1]})`,
+                        width: `${Math.min(100, totals[action.type] * 12)}%`,
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
             </div>
           </div>
-        </section>
 
-        <section className="rounded-3xl border border-white/10 bg-white/5 p-8 text-sm text-slate-200/85">
-          <div className="grid gap-8 lg:grid-cols-2">
-            <div>
-              <h2 className="text-lg font-semibold text-amber-200">How does trust stay sacred?</h2>
-              <p className="mt-3">
-                Every interaction is cryptographically signed, stored with Row Level Security in Supabase, and rendered in real-time via Edge streams. Cloudflare Workers broadcast the state to local mesh kiosks so no village is offline.
-              </p>
-              <p className="mt-3">
-                We honour Nepali first, English second. Buttons breathe, text hums softly, and even without reading you can follow the glow, the water, and the heartbeat.
-              </p>
-            </div>
-            <div className="space-y-3 rounded-2xl border border-white/10 bg-black/40 p-6">
-              <h3 className="text-sm font-semibold text-amber-200">Today&apos;s ritual · आजको रिति</h3>
-              <p className="text-xs text-slate-300/80">
-                Join at dawn, whisper a wish, light a rupee, feel the chorus reply. चौतारीमा भेटौँ।
-              </p>
-              <div className="grid gap-3 sm:grid-cols-2">
-                <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-emerald-500/30 via-emerald-400/20 to-transparent p-4">
-                  <p className="text-xs uppercase tracking-widest text-emerald-200/80">माटो · Earth</p>
-                  <p className="mt-2 text-sm font-semibold text-white">Collective gardens bloom in 42 districts.</p>
-                </div>
-                <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-sky-500/30 via-indigo-500/20 to-transparent p-4">
-                  <p className="text-xs uppercase tracking-widest text-sky-200/80">जल · Water</p>
-                  <p className="mt-2 text-sm font-semibold text-white">Communal cisterns refill through transparent rupee flows.</p>
-                </div>
-                <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-amber-500/30 via-orange-500/20 to-transparent p-4">
-                  <p className="text-xs uppercase tracking-widest text-amber-200/80">आगो · Fire</p>
-                  <p className="mt-2 text-sm font-semibold text-white">Festival nodes bring warmth, music, and nightly assemblies.</p>
-                </div>
-                <div className="rounded-2xl border border-white/10 bg-gradient-to-br from-rose-500/30 via-fuchsia-500/20 to-transparent p-4">
-                  <p className="text-xs uppercase tracking-widest text-rose-200/80">आकाश · Sky</p>
-                  <p className="mt-2 text-sm font-semibold text-white">Voices rise into a public archive of truth.</p>
-                </div>
-              </div>
-            </div>
+          <div className="chautari-panel space-y-3 text-sm text-slate-200/85">
+            <h3 className="text-sm font-semibold text-amber-200">Sunlight Ledger Contract</h3>
+            <p>
+              Actions write themselves into public tables secured by Row Level Security. Merkle proofs and ward attestations follow soon.
+            </p>
+            <ul className="space-y-2 text-xs leading-relaxed text-slate-300/75">
+              <li>• Inserts permitted for authenticated members; reads open to all.</li>
+              <li>• Supabase realtime mirrors every insert to this Mandal instantly.</li>
+              <li>• Voice links remain accessible for community playback layers.</li>
+            </ul>
           </div>
-        </section>
-      </div>
-    </main>
+        </aside>
+      </section>
+
+      <ActionModal
+        open={isModalOpen}
+        action={selectedAction}
+        onClose={() => setIsModalOpen(false)}
+        onLogged={handleLogged}
+      />
+    </div>
   );
 }

--- a/lib/realtime.ts
+++ b/lib/realtime.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { getSupabaseBrowserClient } from "@/lib/supabaseClient";
+import type { RealtimeChannel } from "@supabase/supabase-js";
+import type { ActionType, SunlightAction } from "@/lib/sunlight";
+
+export interface ActionRealtimeCallbacks {
+  onInsert?: (action: SunlightAction) => void;
+}
+
+export function subscribeToActionStream(callbacks: ActionRealtimeCallbacks = {}): RealtimeChannel {
+  const client = getSupabaseBrowserClient();
+  const channel = client
+    .channel("chautari-actions")
+    .on("postgres_changes", { event: "INSERT", schema: "public", table: "actions" }, (payload) => {
+      if (callbacks.onInsert) {
+        callbacks.onInsert(payload.new as SunlightAction);
+      }
+    })
+    .subscribe();
+
+  return channel;
+}
+
+export function actionColor(type: ActionType) {
+  switch (type) {
+    case "seed":
+      return "#4ade80";
+    case "water":
+      return "#38bdf8";
+    case "hive":
+      return "#f97316";
+    case "fire":
+      return "#fb923c";
+    case "whisper":
+      return "#f472b6";
+    case "grain":
+      return "#facc15";
+    case "reflect":
+      return "#a855f7";
+    case "miracle":
+      return "#f59e0b";
+    default:
+      return "#94a3b8";
+  }
+}

--- a/lib/sunlight.ts
+++ b/lib/sunlight.ts
@@ -1,0 +1,193 @@
+"use client";
+
+import { getSupabaseBrowserClient } from "@/lib/supabaseClient";
+import type { RealtimePostgresInsertPayload } from "@supabase/supabase-js";
+
+export type ActionType =
+  | "seed"
+  | "water"
+  | "hive"
+  | "fire"
+  | "whisper"
+  | "grain"
+  | "reflect"
+  | "miracle";
+
+export interface ActionDefinition {
+  type: ActionType;
+  icon: string;
+  label: string;
+  mantra: string;
+  gradient: [string, string];
+  glow: string;
+  description: string;
+}
+
+export interface SunlightAction {
+  id: string;
+  user_id: string;
+  action_type: ActionType;
+  description: string | null;
+  voice_url: string | null;
+  ward_id: number | null;
+  tole_id: number | null;
+  created_at: string;
+}
+
+export const ACTION_DEFINITIONS: Record<ActionType, ActionDefinition> = {
+  seed: {
+    type: "seed",
+    icon: "🌱",
+    label: "Plant a Seed",
+    mantra: "Offer the first light of an idea.",
+    gradient: ["#4ade80", "#bbf7d0"],
+    glow: "rgba(74, 222, 128, 0.4)",
+    description: "Start a community idea, project, or pledge.",
+  },
+  water: {
+    type: "water",
+    icon: "💧",
+    label: "Pour Water",
+    mantra: "Nourish another's work with care.",
+    gradient: ["#38bdf8", "#bae6fd"],
+    glow: "rgba(56, 189, 248, 0.4)",
+    description: "Offer time, skill, or attention to someone else's seed.",
+  },
+  hive: {
+    type: "hive",
+    icon: "🪵",
+    label: "Build the Hive",
+    mantra: "Weave cooperative muscle.",
+    gradient: ["#fde047", "#f97316"],
+    glow: "rgba(249, 115, 22, 0.38)",
+    description: "Join or create a cooperative team and note the first task.",
+  },
+  fire: {
+    type: "fire",
+    icon: "🔥",
+    label: "Offer Fire",
+    mantra: "Bring heat, clarity, and accountability.",
+    gradient: ["#fb923c", "#facc15"],
+    glow: "rgba(251, 146, 60, 0.42)",
+    description: "Vote, verify, or raise a transparency alert.",
+  },
+  whisper: {
+    type: "whisper",
+    icon: "🎶",
+    label: "Send a Whisper",
+    mantra: "Let a story travel on wind.",
+    gradient: ["#f9a8d4", "#f3e8ff"],
+    glow: "rgba(249, 168, 212, 0.36)",
+    description: "Record or link a 30 second voice story.",
+  },
+  grain: {
+    type: "grain",
+    icon: "🌾",
+    label: "Fill the Granary",
+    mantra: "Share tools, rupees, or harvest.",
+    gradient: ["#fcd34d", "#fbbf24"],
+    glow: "rgba(252, 211, 77, 0.4)",
+    description: "Contribute resources into the shared basket.",
+  },
+  reflect: {
+    type: "reflect",
+    icon: "🕊",
+    label: "Reflect at Dusk",
+    mantra: "Pause, breathe, and name what shifted.",
+    gradient: ["#a855f7", "#ddd6fe"],
+    glow: "rgba(168, 85, 247, 0.35)",
+    description: "Write or speak a daily reflection for the circle.",
+  },
+  miracle: {
+    type: "miracle",
+    icon: "🌞",
+    label: "Miracle Moment",
+    mantra: "Synchronize the nation's pulse.",
+    gradient: ["#f97316", "#fde68a"],
+    glow: "rgba(253, 230, 138, 0.4)",
+    description: "Join the weekly unity pulse and log what sparked.",
+  },
+};
+
+export const ORDERED_ACTIONS: ActionDefinition[] = [
+  ACTION_DEFINITIONS.seed,
+  ACTION_DEFINITIONS.water,
+  ACTION_DEFINITIONS.hive,
+  ACTION_DEFINITIONS.fire,
+  ACTION_DEFINITIONS.whisper,
+  ACTION_DEFINITIONS.grain,
+  ACTION_DEFINITIONS.reflect,
+  ACTION_DEFINITIONS.miracle,
+];
+
+const timeFormatter = new Intl.DateTimeFormat("en-GB", {
+  hour: "2-digit",
+  minute: "2-digit",
+  second: "2-digit",
+});
+
+export function formatLedgerTimestamp(iso: string) {
+  return timeFormatter.format(new Date(iso));
+}
+
+export type InsertActionInput = {
+  action_type: ActionType;
+  description?: string;
+  voice_url?: string;
+  ward_id?: number | null;
+  tole_id?: number | null;
+};
+
+export async function logSunlightAction(input: InsertActionInput) {
+  const client = getSupabaseBrowserClient();
+  const {
+    data: { user },
+    error: userError,
+  } = await client.auth.getUser();
+
+  if (userError) {
+    throw userError;
+  }
+
+  if (!user) {
+    throw new Error("You must be signed in to send an action to the ledger.");
+  }
+
+  const payload = {
+    user_id: user.id,
+    action_type: input.action_type,
+    description: input.description?.trim() || null,
+    voice_url: input.voice_url?.trim() || null,
+    ward_id: input.ward_id ?? null,
+    tole_id: input.tole_id ?? null,
+  } satisfies Omit<SunlightAction, "id" | "created_at">;
+
+  const { data, error } = await client
+    .from("actions")
+    .insert(payload)
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data as SunlightAction;
+}
+
+export async function fetchRecentActions(limit = 32) {
+  const client = getSupabaseBrowserClient();
+  const { data, error } = await client
+    .from("actions")
+    .select("id, user_id, action_type, description, voice_url, ward_id, tole_id, created_at")
+    .order("created_at", { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    throw error;
+  }
+
+  return (data ?? []) as SunlightAction[];
+}
+
+export type ActionInsertPayload = RealtimePostgresInsertPayload<SunlightAction>;

--- a/sql/chautari_seed.sql
+++ b/sql/chautari_seed.sql
@@ -1,0 +1,42 @@
+-- Sample sunlight ledger entries for demos
+-- Run after profiles exist; guarded to avoid FK failures when empty.
+
+do $$
+declare
+  anchor uuid;
+  newest uuid;
+  second uuid;
+  third uuid;
+  fourth uuid;
+begin
+  select id into anchor from public.profiles order by created_at asc limit 1;
+  if anchor is null then
+    raise notice 'Skipping Digital Chauṭarī seed — no profiles found.';
+    return;
+  end if;
+
+  select id into newest from public.profiles order by created_at desc limit 1;
+  select id into second from (
+    select id, row_number() over (order by created_at desc) as rn
+    from public.profiles
+  ) ranked where rn = 2;
+  select id into third from (
+    select id, row_number() over (order by created_at desc) as rn
+    from public.profiles
+  ) ranked where rn = 3;
+  select id into fourth from (
+    select id, row_number() over (order by created_at desc) as rn
+    from public.profiles
+  ) ranked where rn = 4;
+
+  insert into public.actions (user_id, action_type, description, voice_url, ward_id, tole_id, created_at)
+  values
+    (coalesce(newest, anchor), 'seed', 'Community orchard proposal drafted with ward elders.', null, 11, 4, timezone('utc', now()) - interval '45 minutes'),
+    (coalesce(second, anchor), 'water', 'Offered nursery time this weekend to tend new saplings.', null, 11, 4, timezone('utc', now()) - interval '38 minutes'),
+    (coalesce(third, anchor), 'hive', 'Three households pledged tools for the cooperative workshop.', null, 12, 7, timezone('utc', now()) - interval '32 minutes'),
+    (coalesce(fourth, anchor), 'fire', 'Verified the ward expense report and raised two clarifying questions.', null, 11, 4, timezone('utc', now()) - interval '27 minutes'),
+    (coalesce(newest, anchor), 'whisper', 'Uploaded an elder''s 30 second blessing for the river cleanup.', 'https://example.org/audio/blessing.mp3', 9, 2, timezone('utc', now()) - interval '21 minutes'),
+    (coalesce(second, anchor), 'grain', 'Delivered 20kg of millet to the communal kitchen.', null, 10, 6, timezone('utc', now()) - interval '16 minutes'),
+    (coalesce(third, anchor), 'reflect', 'The circle felt gentler tonight—youths listened without interrupting.', null, 11, 4, timezone('utc', now()) - interval '9 minutes'),
+    (coalesce(fourth, anchor), 'miracle', 'Ward 11 synced lights at 7pm; 142 participants joined the unity pulse.', null, 11, 4, timezone('utc', now()) - interval '2 minutes');
+end $$;

--- a/styles/chautari.css
+++ b/styles/chautari.css
@@ -1,0 +1,227 @@
+:root {
+  --chautari-bg: radial-gradient(circle at 20% 20%, rgba(244, 196, 91, 0.12), transparent 45%),
+    radial-gradient(circle at 80% 80%, rgba(94, 234, 212, 0.08), transparent 50%),
+    #03030d;
+  --chautari-panel: rgba(12, 11, 21, 0.72);
+  --chautari-border: rgba(255, 255, 255, 0.08);
+  --chautari-gold: #facc6b;
+  --chautari-ember: #fb923c;
+  --chautari-emerald: #34d399;
+  --chautari-azure: #38bdf8;
+  --chautari-rose: #f472b6;
+  --chautari-text: rgba(241, 245, 249, 0.92);
+  --chautari-text-muted: rgba(226, 232, 240, 0.68);
+  --chautari-panel-shadow: 0 30px 120px rgba(250, 204, 107, 0.12);
+}
+
+.chautari-shell {
+  position: relative;
+  min-height: calc(100vh - 4rem);
+  background: var(--chautari-bg);
+  color: var(--chautari-text);
+  padding-bottom: 4rem;
+}
+
+.chautari-shell::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at center, rgba(244, 196, 91, 0.08), transparent 65%);
+  opacity: 0.6;
+}
+
+.chautari-ambient-toggle {
+  position: fixed;
+  right: 1.25rem;
+  bottom: 1.25rem;
+  z-index: 40;
+  backdrop-filter: blur(14px);
+  border-radius: 9999px;
+  padding: 0.6rem 1rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  border: 1px solid rgba(250, 204, 107, 0.28);
+  background: rgba(15, 23, 42, 0.55);
+  color: var(--chautari-gold);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  transition: all 0.2s ease-in-out;
+}
+
+.chautari-ambient-toggle:hover {
+  border-color: rgba(250, 204, 107, 0.65);
+  color: #fff7ec;
+  transform: translateY(-2px);
+}
+
+.chautari-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.chautari-panel {
+  background: var(--chautari-panel);
+  border: 1px solid var(--chautari-border);
+  border-radius: 28px;
+  padding: 1.75rem;
+  box-shadow: var(--chautari-panel-shadow);
+}
+
+.chautari-badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  font-size: 0.65rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--chautari-text-muted);
+}
+
+.chautari-badge {
+  border-radius: 9999px;
+  padding: 0.35rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.chautari-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.chautari-feed-item {
+  display: grid;
+  grid-template-columns: 56px 1fr auto;
+  align-items: center;
+  gap: 1rem;
+  padding: 0.9rem 1.1rem;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: rgba(12, 11, 21, 0.6);
+}
+
+@media (max-width: 640px) {
+  .chautari-feed-item {
+    grid-template-columns: 48px 1fr;
+    grid-template-rows: auto auto;
+  }
+
+  .chautari-feed-item time {
+    grid-column: span 2;
+    justify-self: flex-end;
+  }
+}
+
+.chautari-mandal {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 4 / 3;
+  border-radius: 32px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: radial-gradient(circle at center, rgba(12, 74, 110, 0.15), rgba(8, 47, 73, 0.2));
+  box-shadow: inset 0 0 120px rgba(56, 189, 248, 0.18);
+}
+
+.chautari-mandal canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.chautari-modal-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(3, 3, 12, 0.7);
+  backdrop-filter: blur(18px);
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+}
+
+.chautari-modal {
+  width: min(560px, 100%);
+  background: rgba(7, 11, 25, 0.95);
+  border-radius: 28px;
+  border: 1px solid rgba(250, 204, 107, 0.28);
+  padding: 2rem;
+  color: var(--chautari-text);
+  box-shadow: 0 30px 120px rgba(250, 204, 107, 0.2);
+}
+
+.chautari-modal h2 {
+  font-family: "Cormorant Garamond", "Times New Roman", serif;
+  font-size: 1.6rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--chautari-gold);
+}
+
+.chautari-modal textarea,
+.chautari-modal input {
+  width: 100%;
+  border-radius: 18px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(10, 14, 28, 0.8);
+  color: var(--chautari-text);
+  padding: 0.85rem 1rem;
+  resize: vertical;
+  min-height: 90px;
+  font-size: 0.95rem;
+}
+
+.chautari-modal textarea:focus,
+.chautari-modal input:focus {
+  outline: none;
+  border-color: rgba(250, 204, 107, 0.55);
+  box-shadow: 0 0 0 1px rgba(250, 204, 107, 0.25);
+}
+
+.chautari-modal button[type="submit"] {
+  background: linear-gradient(90deg, rgba(250, 204, 107, 0.92), rgba(251, 146, 60, 0.92));
+  border: none;
+  color: #0f172a;
+  font-weight: 600;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  border-radius: 9999px;
+  padding: 0.85rem 1.6rem;
+  cursor: pointer;
+  transition: transform 0.2s ease-in-out;
+}
+
+.chautari-modal button[type="submit"]:hover {
+  transform: translateY(-2px);
+}
+
+.chautari-modal .chautari-modal-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--chautari-text-muted);
+  margin-top: 1.5rem;
+}
+
+.chautari-stat-bar {
+  height: 6px;
+  width: 100%;
+  border-radius: 9999px;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.chautari-stat-bar span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+}

--- a/supabase/sql/20251103_create_chautari_actions.sql
+++ b/supabase/sql/20251103_create_chautari_actions.sql
@@ -1,0 +1,49 @@
+-- Digital Chauṭarī base schema
+-- Creates the `actions` table, sunlight feed view, realtime publication, and RLS policies.
+
+create table if not exists public.actions (
+  id bigserial primary key,
+  user_id uuid references public.profiles(id) on delete cascade,
+  action_type text check (
+    action_type in (
+      'seed',
+      'water',
+      'hive',
+      'fire',
+      'whisper',
+      'grain',
+      'reflect',
+      'miracle'
+    )
+  ) not null,
+  description text,
+  voice_url text,
+  ward_id bigint,
+  tole_id bigint,
+  created_at timestamptz default timezone('utc', now()) not null
+);
+
+alter table public.actions enable row level security;
+
+create policy if not exists "actions_select_public" on public.actions
+  for select using (true);
+
+create policy if not exists "actions_insert_auth" on public.actions
+  for insert with check (auth.uid() = user_id);
+
+create policy if not exists "actions_update_owner" on public.actions
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+create policy if not exists "actions_delete_owner" on public.actions
+  for delete using (auth.uid() = user_id);
+
+-- realtime broadcast
+alter publication supabase_realtime add table actions;
+
+drop view if exists public.sunlight_feed;
+create view public.sunlight_feed as
+select id, action_type, user_id, created_at
+from public.actions;
+
+comment on table public.actions is 'Sunlight ledger entries representing civic actions on the Digital Chauṭarī.';
+comment on view public.sunlight_feed is 'Public lightweight feed for streaming recent Chauṭarī actions.';


### PR DESCRIPTION
## Summary
- replace the /chautari experience with a modular Digital Chauṭarī canvas, realtime feed, and modal-driven civic actions
- add Supabase helpers for logging actions and broadcasting realtime inserts plus ambient audio wrapper and styling
- define the `actions` table, RLS policies, sunlight view, and provide demo seed data for the Sunlight Ledger

## Testing
- npm run lint *(fails: next binary is unavailable in the container image)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914202e2860832cbb61481bb4992fef)