### PR TITLE
Implement TinaCMS worker and secure admin studio

### DIFF
--- a/app/admin/AdminClient.tsx
+++ b/app/admin/AdminClient.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+
+const TinaAdmin = dynamic(() => import('tinacms').then((mod) => mod.TinaAdmin), {
+  ssr: false,
+});
+
+type Props = {
+  apiUrl: string;
+};
+
+type TinaAdminProps = {
+  apiURL: string;
+};
+
+export default function AdminClient({ apiUrl }: Props) {
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!apiUrl) {
+      setError('Missing Tina GraphQL URL');
+    }
+  }, [apiUrl]);
+
+  const tinaProps: TinaAdminProps = useMemo(
+    () => ({
+      apiURL: apiUrl,
+    }),
+    [apiUrl]
+  );
+
+  if (error) {
+    return (
+      <div className="flex flex-col gap-2 rounded-2xl border border-rose-400/40 bg-rose-400/10 p-6 text-sm text-rose-50">
+        <h2 className="text-lg font-semibold">Unable to start Tina Studio</h2>
+        <p>{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[60vh] rounded-2xl border border-white/10 bg-white/5 p-2">
+      <TinaAdmin {...(tinaProps as any)} />
+    </div>
+  );
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,106 @@
+import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
+import { getSupabaseServer } from '@/lib/supabase/server';
+import AdminClient from './AdminClient';
+
+const allowedRoles = new Set(['admin', 'editor']);
+
+type RoleLike = string | string[] | null | undefined;
+
+function extractRole(roleLike: RoleLike): string | null {
+  if (!roleLike) return null;
+  if (Array.isArray(roleLike)) {
+    return roleLike.find((value) => allowedRoles.has(value)) ?? null;
+  }
+  if (allowedRoles.has(roleLike)) {
+    return roleLike;
+  }
+  return null;
+}
+
+async function resolveRole(user: any): Promise<string | null> {
+  if (!user) return null;
+  const meta = user.app_metadata ?? {};
+  const userMeta = user.user_metadata ?? {};
+  return (
+    extractRole(meta.role as RoleLike) ||
+    extractRole(meta.roles as RoleLike) ||
+    extractRole(userMeta.role as RoleLike) ||
+    extractRole(userMeta.roles as RoleLike) ||
+    null
+  );
+}
+
+function Loading() {
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="flex items-center gap-3 text-sm text-neutral-500">
+        <span className="h-3 w-3 animate-ping rounded-full bg-amber-400" aria-hidden />
+        <span>Loading Tina Studio…</span>
+      </div>
+    </div>
+  );
+}
+
+function MissingConfig({ message }: { message: string }) {
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4 rounded-2xl border border-white/10 bg-white/5 p-8 text-center text-sm text-white/70">
+      <h1 className="text-lg font-semibold text-white">CMS configuration missing</h1>
+      <p>{message}</p>
+      <p>
+        Update your deployment environment with <code className="rounded bg-black/40 px-1">NEXT_PUBLIC_TINA_API_URL</code>
+        {' '}
+        and refresh this page.
+      </p>
+    </div>
+  );
+}
+
+function Unauthorized() {
+  return (
+    <div className="mx-auto flex max-w-xl flex-col gap-4 rounded-2xl border border-rose-500/40 bg-rose-500/10 p-8 text-center text-sm text-rose-100">
+      <h1 className="text-lg font-semibold">Access restricted</h1>
+      <p>You need an admin or editor role to manage content.</p>
+    </div>
+  );
+}
+
+export default async function AdminPage() {
+  const supabase = getSupabaseServer();
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser();
+
+  if (error || !user) {
+    redirect(`/login?next=/admin`);
+  }
+
+  const role = await resolveRole(user);
+  if (!role) {
+    return (
+      <main className="flex min-h-screen flex-col gap-12 bg-slate-950 px-6 py-16 text-white">
+        <Unauthorized />
+      </main>
+    );
+  }
+
+  const apiUrl = process.env.NEXT_PUBLIC_TINA_API_URL;
+  if (!apiUrl) {
+    return (
+      <main className="flex min-h-screen flex-col gap-12 bg-slate-950 px-6 py-16 text-white">
+        <MissingConfig message="The Tina GraphQL endpoint URL is not configured." />
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-2 py-8 text-white sm:px-6">
+      <div className="mx-auto w-full max-w-6xl rounded-3xl border border-white/10 bg-slate-900/80 p-4 shadow-xl ring-1 ring-black/40">
+        <Suspense fallback={<Loading />}>
+          <AdminClient apiUrl={apiUrl} />
+        </Suspense>
+      </div>
+    </main>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "react-markdown": "9.0.1",
     "remark-gfm": "4.0.0",
     "three": "0.169.0",
+    "tinacms": "^1.5.57",
+    "@tinacms/schema-tools": "^1.5.57",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -42,6 +44,7 @@
     "prettier": "3.3.3",
     "tailwindcss": "3.4.13",
     "typescript": "5.6.2",
+    "@cloudflare/workers-types": "^4.20241022.0",
     "vitest": "1.6.0"
   }
 }

--- a/tina/config.ts
+++ b/tina/config.ts
@@ -1,0 +1,115 @@
+import { defineConfig } from 'tinacms';
+
+const branch =
+  process.env.VERCEL_GIT_COMMIT_REF ||
+  process.env.NEXT_PUBLIC_VERCEL_BRANCH ||
+  process.env.HEAD ||
+  'main';
+
+const tinaApiUrl =
+  process.env.NEXT_PUBLIC_TINA_API_URL ||
+  'https://edit.gatishilnepal.org/tina/graphql';
+
+const repository =
+  process.env.GITHUB_REPOSITORY ||
+  process.env.NEXT_PUBLIC_GITHUB_REPOSITORY ||
+  'gatishil/GatishilNepal';
+
+export default defineConfig({
+  branch,
+  clientId: '',
+  token: '',
+  apiURL: tinaApiUrl,
+  storage: {
+    manager: {
+      github: {
+        repo: repository,
+        branch,
+      },
+    },
+    media: {
+      r2: {
+        bucket: process.env.R2_BUCKET || 'tina-content',
+        accountId: process.env.R2_ACCOUNT_ID || '',
+      },
+    },
+  },
+  media: {
+    tina: {
+      publicFolder: 'public',
+      mediaRoot: 'uploads',
+    },
+  },
+  schema: {
+    collections: [
+      {
+        name: 'blog',
+        label: 'Blog Posts',
+        path: 'content/blog',
+        format: 'mdx',
+        ui: {
+          allowedActions: {
+            create: true,
+            delete: true,
+          },
+        },
+        fields: [
+          {
+            type: 'string',
+            name: 'title',
+            label: 'Title',
+            required: true,
+          },
+          {
+            type: 'string',
+            name: 'title_en',
+            label: 'Title (English)',
+          },
+          {
+            type: 'string',
+            name: 'title_np',
+            label: 'Title (Nepali)',
+          },
+          {
+            type: 'string',
+            name: 'slug',
+            label: 'Slug',
+            required: true,
+            ui: {
+              description: 'Used for the blog URL.',
+            },
+          },
+          {
+            type: 'string',
+            name: 'author',
+            label: 'Author',
+          },
+          {
+            type: 'datetime',
+            name: 'published_at',
+            label: 'Published At',
+            ui: {
+              timeFormat: 'HH:mm',
+            },
+          },
+          {
+            type: 'rich-text',
+            name: 'body',
+            label: 'Body',
+            isBody: true,
+          },
+          {
+            type: 'rich-text',
+            name: 'body_en',
+            label: 'Body (English)',
+          },
+          {
+            type: 'rich-text',
+            name: 'body_np',
+            label: 'Body (Nepali)',
+          },
+        ],
+      },
+    ],
+  },
+});

--- a/workers/tina-graphql-worker.ts
+++ b/workers/tina-graphql-worker.ts
@@ -1,0 +1,115 @@
+import { createTinaHandler } from 'tinacms/graphql';
+import { createSchema } from '@tinacms/schema-tools';
+import type { ExecutionContext } from '@cloudflare/workers-types';
+import tinaConfig from '../tina/config';
+
+type Env = {
+  GITHUB_TOKEN: string;
+  GITHUB_REPOSITORY?: string;
+  GITHUB_BRANCH?: string;
+  R2_BUCKET: string;
+  R2_ACCOUNT_ID: string;
+  R2_ACCESS_KEY_ID: string;
+  R2_SECRET_ACCESS_KEY: string;
+};
+
+type TinaHandler = (
+  request: Request,
+  context?: { env: Env; executionCtx: ExecutionContext }
+) => Promise<Response>;
+
+const schema = createSchema(tinaConfig as any);
+
+const corsHeaders: Record<string, string> = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization, x-tina-commit-type',
+  'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+  'Access-Control-Allow-Credentials': 'true',
+};
+
+function withCors(response: Response): Response {
+  const headers = new Headers(response.headers);
+  for (const [key, value] of Object.entries(corsHeaders)) {
+    headers.set(key, value);
+  }
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+async function buildHandler(env: Env): Promise<TinaHandler> {
+  const [owner, repo] = (env.GITHUB_REPOSITORY ?? 'gatishil/GatishilNepal').split('/');
+  const branch = env.GITHUB_BRANCH ?? (tinaConfig as any).branch ?? 'main';
+
+  return createTinaHandler({
+    config: tinaConfig as any,
+    schema,
+    context: {
+      env: {
+        github: {
+          token: env.GITHUB_TOKEN,
+          owner,
+          repo,
+          branch,
+        },
+        media: {
+          r2: {
+            bucket: env.R2_BUCKET,
+            accountId: env.R2_ACCOUNT_ID,
+            accessKeyId: env.R2_ACCESS_KEY_ID,
+            secretAccessKey: env.R2_SECRET_ACCESS_KEY,
+          },
+        },
+      },
+    },
+  } as any);
+}
+
+export default {
+  async fetch(request: Request, env: Env, executionCtx: ExecutionContext): Promise<Response> {
+    const url = new URL(request.url);
+    if (url.pathname !== '/tina/graphql') {
+      return withCors(
+        new Response(JSON.stringify({ error: 'Not Found' }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+    }
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: corsHeaders });
+    }
+
+    try {
+      const handler = await buildHandler(env);
+      const response = await handler(request, { env, executionCtx });
+      const type = response.headers.get('content-type');
+      if (!type) {
+        const headers = new Headers(response.headers);
+        headers.set('Content-Type', 'application/json');
+        return withCors(
+          new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          })
+        );
+      }
+      return withCors(response);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return withCors(
+        new Response(
+          JSON.stringify({ error: message }),
+          {
+            status: 500,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      );
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- add a Cloudflare Worker Tina GraphQL handler that wires GitHub commits and R2 media storage
- define TinaCMS configuration for bilingual MDX blog content and media handling
- build a Supabase-gated admin page that loads Tina Studio via dynamic import and friendly fallbacks

## Testing
- npm install *(fails: registry returned 403 for @node-rs/argon2)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69146295e2d4832c85e6b2fa7485d3a7)