### PR TITLE
Mark Supabase-powered pages as client-only

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,5 +1,6 @@
 // app/admin/page.tsx
 "use client";
+export const dynamic = "force-dynamic";
 
 import dynamic from "next/dynamic";
 import { useEffect, useState } from "react";

--- a/app/auth/callback/Client.tsx
+++ b/app/auth/callback/Client.tsx
@@ -1,5 +1,6 @@
 // app/auth/callback/Client.tsx
 "use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";

--- a/app/blog/editor/page.tsx
+++ b/app/blog/editor/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";

--- a/app/chautari/page.tsx
+++ b/app/chautari/page.tsx
@@ -1,4 +1,5 @@
 "use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";

--- a/app/join/JoinClient.tsx
+++ b/app/join/JoinClient.tsx
@@ -1,4 +1,5 @@
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import { Suspense, useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -1,5 +1,6 @@
 // app/members/page.tsx
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from 'react';
 import { User } from '@supabase/supabase-js';

--- a/app/onboard/TrustStep.jsx
+++ b/app/onboard/TrustStep.jsx
@@ -1,4 +1,5 @@
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import React, { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -1,9 +1,8 @@
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
-import { Suspense } from 'react';
-import OnboardingFlow from '@/components/OnboardingFlow';
-
-export const dynamic = 'force-dynamic';
+import { Suspense } from "react";
+import OnboardingFlow from "@/components/OnboardingFlow";
 
 function Flow() {
   // Keep this tiny wrapper so Suspense can isolate the hook usage inside the tree.

--- a/app/security/SecurityClient.tsx
+++ b/app/security/SecurityClient.tsx
@@ -1,5 +1,6 @@
 // app/security/SecurityClient.tsx — CLIENT logic (hooks + Supabase)
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,5 +1,6 @@
 // app/status/page.tsx
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase/unifiedClient';

--- a/app/welcome/Client.tsx
+++ b/app/welcome/Client.tsx
@@ -1,4 +1,5 @@
-'use client';
+"use client";
+export const dynamic = "force-dynamic";
 
 import { useEffect, useState } from 'react';
 import { useSearchParams } from 'next/navigation';

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -1,9 +1,10 @@
-// Server wrapper for /welcome
-import { Suspense } from 'react';
-import Client from './Client';
-import Card from '@/components/Card';
+"use client";
+export const dynamic = "force-dynamic";
 
-export const dynamic = 'force-dynamic';
+// Server wrapper for /welcome
+import { Suspense } from "react";
+import Client from "./Client";
+import Card from "@/components/Card";
 export const revalidate = false;
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- ensure all Supabase-backed app pages and clients are marked as client components
- add `export const dynamic = "force-dynamic";` so Next.js skips prerendering those browser-only modules
- convert `/welcome/page.tsx` to a client wrapper to keep Supabase helpers out of the server bundle

## Testing
- npm run build *(fails: `next` binary missing because dependencies could not be installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691471e1f584832cabaf7f957f72e220)