### PR TITLE
Rename admin dynamic import to avoid name clash

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -2,12 +2,12 @@
 "use client";
 export const dynamic = "force-dynamic";
 
-import dynamic from "next/dynamic";
+import nextDynamic from "next/dynamic";
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { supabase } from "@/lib/supabase/unifiedClient";
 
-const AdminClient = dynamic(() => import("./AdminClient"), { ssr: false });
+const AdminClient = nextDynamic(() => import("./AdminClient"), { ssr: false });
 
 export default function AdminPage() {
   const [allowed, setAllowed] = useState(false);


### PR DESCRIPTION
## Summary
- rename the `next/dynamic` import in `app/admin/page.tsx` to `nextDynamic`
- update the admin dynamic import usage to match the renamed symbol

## Testing
- `npm run build` *(fails: sh: 1: next: not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691474a2bdfc832c961fddd491f18583)