### PR TITLE
fix: migrate Supabase helpers to @supabase/ssr and correct revalidate exports

### DIFF
--- a/AUTH_CONTROL_TOWER.md
+++ b/AUTH_CONTROL_TOWER.md
@@ -37,7 +37,7 @@ This control tower distills every moving part of Gatishil Nepal’s authenticati
 | --- | --- | --- | --- | --- |
 | `lib/supabaseClient.ts` | Client-only re-export of Supabase browser singleton. | `supabase`, `getSupabaseBrowser`. | Most client flows (Join, onboarding, login). | Wraps `lib/supabase/browser`. |
 | `lib/supabase/browser.ts` | Creates singleton browser client and mirrors tokens into cookies. | `getSupabaseBrowser`, `supabase`. | Login & onboarding UIs. | Syncs via `/api/auth/sync` on sign-in/refresh. |
-| `lib/supabase/server.ts` | SSR Supabase client respecting modern & legacy cookies. | `getSupabaseServer`. | `/dashboard`. | Reads `sb-*` cookies, falls back to legacy JSON. |
+| `lib/supabase/server.ts` | SSR Supabase client respecting modern cookies API. | `supabaseServer`. | `/dashboard`. | Uses `@supabase/ssr` helpers with Next.js cookies. |
 | `lib/supabaseServer.ts` | Older server helper with writeable cookies. | `getServerSupabase`. | `/login`. | Supports legacy cookie decoding. |
 | `lib/auth/verifyOtpClient.ts` | Legacy browser helper for the old unified `/api/otp/verify` endpoint. | `verifyOtpAndSync`. | *(unused after OTP lane split)*. | Retained for reference; new flows call Supabase directly for email and `/api/otp/phone/verify` for SMS. |
 | `lib/auth/waitForSession.ts` | Polls Supabase until a session appears. | `waitForSession`. | `verifyOtpAndSync`, `/join` email flow. | Returns tokens for cookie sync. |

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,13 +1,13 @@
 import { ReactNode } from 'react';
 import { redirect } from 'next/navigation';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
 export const fetchCache = 'force-no-store';
 
 export default async function ProtectedLayout({ children }: { children: ReactNode }) {
-  const supa = getSupabaseServer();
+  const supa = supabaseServer();
   const { data: { user } } = await supa.auth.getUser();
 
   if (!user) {

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 // app/admin/page.tsx
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import nextDynamic from "next/dynamic";
 import { useEffect, useState } from "react";

--- a/app/api/auth/exchange/route.ts
+++ b/app/api/auth/exchange/route.ts
@@ -2,7 +2,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 import { NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export async function POST(req: Request) {
   try {
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ ok: false, error: 'code_required' }, { status: 400 });
     }
 
-    const supabase = getSupabaseServer();
+    const supabase = supabaseServer();
     const { data, error } = await supabase.auth.exchangeCodeForSession(code);
     if (error) {
       return NextResponse.json({ ok: false, error: error.message }, { status: 400 });

--- a/app/api/auth/session/route.ts
+++ b/app/api/auth/session/route.ts
@@ -1,13 +1,13 @@
 // app/api/auth/session/route.ts
 import { NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
   try {
-    const supabase = getSupabaseServer();
+    const supabase = supabaseServer();
     const { data: { user }, error } = await supabase.auth.getUser();
     if (error) {
       return NextResponse.json({ authenticated: false, error: 'no-user' }, { status: 200, headers: { 'Cache-Control': 'no-store' } });

--- a/app/api/auth/sync/route.ts
+++ b/app/api/auth/sync/route.ts
@@ -1,6 +1,6 @@
 // app/api/auth/sync/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 
@@ -8,9 +8,8 @@ export const runtime = 'nodejs';
  * GET /api/auth/sync
  * Returns { authenticated } by reading server cookies.
  */
-export async function GET(req: NextRequest) {
-  const res = new NextResponse(null, { status: 200 });
-  const supabase = getSupabaseServer({ request: req, response: res });
+export async function GET() {
+  const supabase = supabaseServer();
 
   const { data } = await supabase.auth.getUser();
   return NextResponse.json({ authenticated: !!data?.user }, { status: 200 });
@@ -29,8 +28,6 @@ export async function GET(req: NextRequest) {
  */
 export async function POST(req: NextRequest) {
   try {
-    const res = new NextResponse(null, { status: 200 });
-
     // Read tokens from JSON body (or fallback to headers)
     let access_token = '';
     let refresh_token = '';
@@ -63,7 +60,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Create server client bound to this response and set the session
-    const supabase = getSupabaseServer({ request: req, response: res });
+    const supabase = supabaseServer();
     const { error: setErr } = await supabase.auth.setSession({
       access_token,
       refresh_token,
@@ -83,7 +80,7 @@ export async function POST(req: NextRequest) {
 
     return NextResponse.json(
       { ok: true, user: { id: userData.user.id, email: userData.user.email } },
-      { status: 200, headers: res.headers }
+      { status: 200 }
     );
   } catch (e: any) {
     return NextResponse.json(

--- a/app/api/otp/send/route.ts
+++ b/app/api/otp/send/route.ts
@@ -1,11 +1,8 @@
 // app/api/otp/send/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
-
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const SUPABASE_ANON = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
 
 const normalizePhone = (raw: string) => {
   const trimmed = (raw ?? '').trim();
@@ -33,8 +30,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid phone' }, { status: 400 });
     }
 
-    const res = new NextResponse(null, { status: 204 });
-    const supabase = getSupabaseServer({ request: req, response: res });
+    const supabase = supabaseServer();
 
     const { error } = await supabase.auth.signInWithOtp({ phone });
     if (error) {
@@ -44,7 +40,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: msg }, { status });
     }
 
-    return res; // 204
+    return new NextResponse(null, { status: 204 });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 });
   }

--- a/app/api/otp/verify/route.ts
+++ b/app/api/otp/verify/route.ts
@@ -1,6 +1,6 @@
 // app/api/otp/verify/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 
@@ -35,9 +35,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid phone or token' }, { status: 400 });
     }
 
-    // Attach cookies to THIS response instance
-    const res = new NextResponse(null, { status: 204 });
-    const supabase = getSupabaseServer({ request: req, response: res });
+    const supabase = supabaseServer();
 
     // 1) Verify OTP on the server (should return a session)
     const { data, error } = await supabase.auth.verifyOtp({
@@ -61,8 +59,8 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No session after verify' }, { status: 401 });
     }
 
-    // Success: cookies are now on `res`, client should redirect on 204
-    return res;
+    // Success: cookies are now stored; respond 204 to trigger client redirect
+    return new NextResponse(null, { status: 204 });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 });
   }

--- a/app/api/pin/login/route.ts
+++ b/app/api/pin/login/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
 import { derivePasswordFromPinSync } from '@/lib/crypto/pin';
 import { normalizeNepalToDB } from '@/lib/phone/nepal';
@@ -115,8 +115,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Account email missing' }, { status: 500 });
     }
 
-    const res = new NextResponse(null, { status: 204 });
-    const supabaseSSR = getSupabaseServer({ request: req, response: res });
+    const supabaseSSR = supabaseServer();
 
     let { error: signInErr } = await supabaseSSR.auth.signInWithPassword({
       email: authEmail,
@@ -145,7 +144,7 @@ export async function POST(req: NextRequest) {
       }
     }
 
-    return res;
+    return new NextResponse(null, { status: 204 });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Unexpected error' }, { status: 500 });
   }

--- a/app/api/pin/set/route.ts
+++ b/app/api/pin/set/route.ts
@@ -1,6 +1,6 @@
 // app/api/pin/set/route.ts
 import { NextRequest, NextResponse } from 'next/server';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 import { getSupabaseAdmin } from '@/lib/supabaseAdmin';
 import { derivePasswordFromPinSync } from '@/lib/crypto/pin';
 import { randomBytes } from 'crypto';
@@ -33,9 +33,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'Invalid PIN' }, { status: 400 });
     }
 
-    // Bind SSR client to request/response cookies
-    const res = new NextResponse(null, { status: 204 });
-    const supabaseSSR = getSupabaseServer({ request: req, response: res });
+    const supabaseSSR = supabaseServer();
 
     // Must be signed in to set a PIN
     const { data: me, error: meErr } = await supabaseSSR.auth.getUser();
@@ -129,7 +127,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Success → client should redirect to /dashboard on 204
-    return res;
+    return new NextResponse(null, { status: 204 });
   } catch (e: any) {
     return NextResponse.json({ error: e?.message || 'Server error' }, { status: 500 });
   }

--- a/app/blog/editor/page.tsx
+++ b/app/blog/editor/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";

--- a/app/chautari/page.tsx
+++ b/app/chautari/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,7 +1,7 @@
 // app/dashboard/page.tsx
 import React from 'react';
 import { redirect } from 'next/navigation';
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -38,7 +38,7 @@ function Pill({ children }: { children: React.ReactNode }) {
 
 export default async function DashboardPage() {
   // SERVER is the single source of truth. No client redirects, no loops.
-  const supabase = getSupabaseServer();
+  const supabase = supabaseServer();
 
   const { data: userRes, error: userErr } = await supabase.auth.getUser();
   // If auth lookup itself failed or there is no user → go to login (once).

--- a/app/members/page.tsx
+++ b/app/members/page.tsx
@@ -1,6 +1,7 @@
 // app/members/page.tsx
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import { useEffect, useState } from 'react';
 import { User } from '@supabase/supabase-js';

--- a/app/onboard/page.tsx
+++ b/app/onboard/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import { Suspense } from "react";
 import OnboardingFlow from "@/components/OnboardingFlow";

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,6 +1,7 @@
 // app/status/page.tsx
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 import { useEffect, useState } from 'react';
 import { supabase } from '@/lib/supabase/client';

--- a/app/welcome/page.tsx
+++ b/app/welcome/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 export const dynamic = "force-dynamic";
+export const revalidate = false;
 
 // Server wrapper for /welcome
 import { Suspense } from "react";
 import Client from "./Client";
 import Card from "@/components/Card";
-export const revalidate = false;
 
 export default function Page() {
   return (

--- a/docs/AUTH_CONTROL_TOWER.md
+++ b/docs/AUTH_CONTROL_TOWER.md
@@ -2,7 +2,7 @@
 
 **Status note:** Email/Phone OTP → Onboard desync was traced to cookie commits and schema drift.
 
-- `/api/auth/sync` now standardizes on `getSupabaseServer({ response })` and commits cookies on every POST/GET.
+- `/api/auth/sync` now standardizes on `supabaseServer()` and commits cookies on every POST/GET.
 - OTP handlers in `lib/otp.ts` call `commitCookies(res)` after successful verification, eliminating middleware loops.
 
 **Resolved items**

--- a/docs/auth-audit.md
+++ b/docs/auth-audit.md
@@ -196,12 +196,12 @@ if (!isSignedIn(req)) {
 }
 ```
 
-- **Protected layout:** `app/(protected)/layout.tsx` also guards server-rendered routes, calling `getSupabaseServer().auth.getUser()` and `redirect('/login?next=/dashboard')` when no user is returned. This runs after middleware and depends on server cookies being present.
+- **Protected layout:** `app/(protected)/layout.tsx` also guards server-rendered routes, calling `supabaseServer().auth.getUser()` and `redirect('/login?next=/dashboard')` when no user is returned. This runs after middleware and depends on server cookies being present.
 
 _Server layout enforces login if Supabase server client has no user._
 ```tsx
 // app/(protected)/layout.tsx (lines 7-16)
-const supa = getSupabaseServer();
+const supa = supabaseServer();
 const { data: { user } } = await supa.auth.getUser();
 
 if (!user) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,9 +1,10 @@
 // lib/db.ts
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from "@/lib/supabase/server";
 
 // Canonical export
-export { getSupabaseServer };
+export { supabaseServer };
 
 // Back-compat aliases used elsewhere in the codebase
-export const getServerSupabase = getSupabaseServer;
-export const getSupabase = getSupabaseServer;
+export const getSupabaseServer = supabaseServer;
+export const getServerSupabase = supabaseServer;
+export const getSupabase = supabaseServer;

--- a/lib/otp.ts
+++ b/lib/otp.ts
@@ -1,6 +1,5 @@
 import { NextResponse } from "next/server";
-import type { Database } from "@/types/supabase";
-import { getSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 /**
  * Unified OTP (Email + Phone/SMS) for Next.js App Router.
@@ -33,7 +32,7 @@ function isPhoneVerify(p: any): p is { phone: string; token: string } {
 }
 
 export async function handleSend(req: Request): Promise<Response> {
-  const supabase = getSupabaseServer();
+  const supabase = supabaseServer();
 
   let body: SendPayload;
   try {
@@ -85,7 +84,7 @@ export async function handleSend(req: Request): Promise<Response> {
 }
 
 export async function handleVerify(req: Request): Promise<Response> {
-  const supabase = getSupabaseServer();
+  const supabase = supabaseServer();
 
   let body: VerifyPayload;
   try {

--- a/lib/requireSessionUser.ts
+++ b/lib/requireSessionUser.ts
@@ -1,18 +1,18 @@
-import { getSupabaseServer } from '@/lib/supabase/server';
+import { supabaseServer } from "@/lib/supabase/server";
 
 /**
  * Ensures a valid Supabase session in server routes.
  * Throws if unauthenticated. Used in API handlers or server components.
  */
 export async function requireSessionUser() {
-  const supabase = getSupabaseServer();
+  const supabase = supabaseServer();
   const {
     data: { user },
     error,
   } = await supabase.auth.getUser();
 
   if (error || !user) {
-    throw new Error('UNAUTHENTICATED');
+    throw new Error("UNAUTHENTICATED");
   }
 
   return user;

--- a/lib/spine.ts
+++ b/lib/spine.ts
@@ -3,10 +3,10 @@
 
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { Database } from "@/types/supabase";
-import { getSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
 function createClient(): SupabaseClient<Database> {
-  return getSupabaseServer();
+  return supabaseServer();
 }
 
 /**

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,41 +1,9 @@
-import { cookies as nextCookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
-import type { NextRequest, NextResponse } from "next/server";
-import type { Database } from "@/types/supabase";
+import { cookies } from "next/headers";
 
-type ServerContext = {
-  request?: NextRequest;
-  response?: NextResponse;
-};
-
-const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
-const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-
-if (!url || !anon) {
-  throw new Error("Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY");
-}
-
-export function getSupabaseServer(context?: ServerContext) {
-  if (context?.request && context?.response) {
-    const { request, response } = context;
-    return createServerClient<Database>(url, anon, {
-      cookies: {
-        get(name: string) {
-          return request.cookies.get(name)?.value;
-        },
-        set(name: string, value: string, options) {
-          response.cookies.set({ name, value, ...(options ?? {}) });
-        },
-        remove(name: string, options) {
-          response.cookies.set({ name, value: "", ...(options ?? {}), maxAge: 0 });
-        },
-      },
-    });
-  }
-
-  return createServerClient<Database>(url, anon, {
-    cookies: nextCookies,
-  });
-}
-
-export default getSupabaseServer;
+export const supabaseServer = () =>
+  createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { cookies }
+  );

--- a/lib/supabaseServer.ts
+++ b/lib/supabaseServer.ts
@@ -1,5 +1,6 @@
-import { getSupabaseServer } from "@/lib/supabase/server";
+import { supabaseServer } from "@/lib/supabase/server";
 
-export { getSupabaseServer };
-export const getServerSupabase = getSupabaseServer;
-export default getSupabaseServer;
+export { supabaseServer };
+export const getSupabaseServer = supabaseServer;
+export const getServerSupabase = supabaseServer;
+export default supabaseServer;


### PR DESCRIPTION
## Summary
- replace the server-side Supabase helper with the @supabase/ssr client and update shared utilities and API routes to consume the new `supabaseServer()` factory
- add explicit `revalidate = false` exports to Supabase-backed client pages to resolve invalid revalidation warnings
- refresh documentation references to point at the new server helper name

## Testing
- npm run build *(fails: `next` binary unavailable because dependencies cannot be installed in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914781047e0832c99622e13e523f439)