### PR TITLE
fix: correct invalid revalidate exports to false on all dynamic Supabase pages

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -3,7 +3,7 @@ import { redirect } from 'next/navigation';
 import { supabaseServer } from '@/lib/supabase/server';
 
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+export const revalidate = false;
 export const fetchCache = 'force-no-store';
 
 export default async function ProtectedLayout({ children }: { children: ReactNode }) {

--- a/app/api/hello/route.ts
+++ b/app/api/hello/route.ts
@@ -1,6 +1,6 @@
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
-export const revalidate = 0;
+export const revalidate = false;
 
 export async function GET() {
   return new Response(JSON.stringify({ ok: true, msg: 'API is alive' }), {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import { supabaseServer } from '@/lib/supabase/server';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+export const revalidate = false;
 
 const AVATAR_HOST_SUFFIXES = ['supabase.co', 'googleusercontent.com'];
 const AVATAR_EXACT_HOSTS = new Set([

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+export const revalidate = false;
 export const fetchCache = 'force-no-store';
 
 import LoginClient from './LoginClient';

--- a/app/tax/calculator/page.tsx
+++ b/app/tax/calculator/page.tsx
@@ -2,7 +2,7 @@
 import NextDynamic from 'next/dynamic';
 
 export const dynamic = 'force-dynamic';
-export const revalidate = 0;
+export const revalidate = false;
 
 const Chrome = NextDynamic(() => import('./Chrome'), { ssr: true });
 


### PR DESCRIPTION
## Summary
- replace remaining `export const revalidate = 0` usages in the app directory with `export const revalidate = false` for proper static export semantics
- align the protected layout, dashboard, login page, calculator page, and hello API route with the required boolean revalidation value

## Testing
- npm install *(fails: registry returned 403 for @cloudflare/workers-types)*
- npm run build *(fails: `next` binary unavailable without dependencies)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69147ab7b48c832c9d78ddc660ea5ce5)